### PR TITLE
[Reviewer: Andy] Allow empty etcd_cluster

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -142,14 +142,14 @@ join_cluster()
 #
 join_or_create_cluster()
 {
-    export ETCD_NAME=${local_ip//./-}
+	export ETCD_NAME=${local_ip//./-}
 
-    if [[ $etcd_cluster =~ (^|,)$local_ip(,|$) ]]
-    then
-      create_cluster
-   else
-      join_cluster
-   fi
+	if [[ $etcd_cluster =~ (^|,)$local_ip(,|$) ]]
+	then
+	  create_cluster
+	else
+	  join_cluster
+	fi
 }
 
 wait_for_etcd()
@@ -181,6 +181,13 @@ do_start()
           # We'll start normally using the data we saved off on our last boot.
           echo "Rejoining cluster..."
         else
+          # Exit if the etcd_cluster value hasn't been set
+          if [ -z "$etcd_cluster" ]
+          then
+            echo "Can't start clearwater-etcd without a etcd_cluster setting in /etc/clearwater/config"
+            return 2
+          fi
+
           join_or_create_cluster
         fi
 

--- a/debian/rules
+++ b/debian/rules
@@ -28,6 +28,6 @@ override_dh_auto_install:
 
 # Don't start - monit does that for us.
 override_dh_installinit:
-	dh_installinit -u"defaults 60 40"
+	dh_installinit --no-start -u"defaults 60 40"
 
 override_dh_shlibdeps:


### PR DESCRIPTION
Can you review this change to stop clearwater-etcd from starting if there's no etcd_cluster setting, rather than crashing. 