### PR TITLE
Reviewer RKD: Live test fixes

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -242,6 +242,14 @@ class EtcdSynchronizer(object):
                         # - unless we're terminating, we'll stay in the while
                         # loop and try again
                         pass
+                    except etcd.EtcdException as e:
+                        # We have seen timeouts getting raised as EtcdExceptions
+                        # so catch these here too and treat them as timeouts if
+                        # they indicate that the read timed out.
+                        if "Read timed out" in e.message:
+                            pass
+                        else:
+                            raise
                     except ValueError:
                         # The index isn't valid to watch on, probably because
                         # there has been a snapshot between the get and the

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -101,6 +101,7 @@ class EtcdSynchronizer(object):
                 self.write_to_etcd(cluster_view, new_state)
             else:
                 _log.debug("No state change")
+        _log.info("Quitting FSM")
         self._fsm.quit()
 
     def parse_cluster_view(self, view):
@@ -230,7 +231,7 @@ class EtcdSynchronizer(object):
                           cluster_view,
                           self._last_cluster_view))
             if cluster_view == self._last_cluster_view:
-                while not self._terminate_flag:
+                while not self._terminate_flag and self._fsm.is_running():
                     try:
                         result = self._client.watch(self._key,
                                                     index=result.modifiedIndex+1,

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -130,8 +130,8 @@ def main(args):
 
     install_sigquit_handler(synchronizers)
 
-    while True:
-        for thread in threads:
+    for thread in threads:
+        while thread.isAlive():
             thread.join(1)
 
 if __name__ == '__main__':

--- a/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
@@ -156,8 +156,8 @@ def leave_cassandra_cluster():
     except:
         start_cassandra()
 
+    run_command("monit unmonitor cassandra")
     run_command("nodetool decommission")
-    _log.debug("Cassandra node successfully decommissioned")
 
 
 def start_cassandra():


### PR DESCRIPTION
Largely discussed live test fixes. Unclustering cassandra is now much quicker; however there is still a lengthy wait after the cassandra is removed from the cluster before quiescing the node finishes.

@eleanor-merry may be interested too