### PR TITLE
[Reviewer: Andy] Traffic separation

### DIFF
--- a/debian/clearwater-etcd.postinst
+++ b/debian/clearwater-etcd.postinst
@@ -80,8 +80,6 @@ case "$1" in
         setup_data_dir
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-etcd.monit /etc/monit/conf.d/
         reload clearwater-monit || /bin/true
-
-        pip install python-etcd
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
This:
* differentiates between the "listen IP" and the "advertisement IP", potentially allowing us to advertise EC2 public IPs in future
* defaults both to $management_local_ip