### PR TITLE
[Reviewer: Ellie] Don't tight-loop if the etcd key doesn't exist

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -268,6 +268,7 @@ class EtcdSynchronizer(object):
             # Save off the index of the result we're using for when we write
             # back to etcd later.
             self._index = result.modifiedIndex
+            self._last_cluster_view = cluster_view.copy()
 
         except etcd.EtcdKeyError:
             # If the key doesn't exist in etcd then there is currently no
@@ -286,7 +287,6 @@ class EtcdSynchronizer(object):
             # The main loop (which reads from etcd in a loop) should call this
             # function again after we return, causing the read to be retried.
 
-        self._last_cluster_view = cluster_view.copy()
         return cluster_view
 
     # Write the new cluster view to etcd. We may be expecting to create the key

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -268,7 +268,6 @@ class EtcdSynchronizer(object):
             # Save off the index of the result we're using for when we write
             # back to etcd later.
             self._index = result.modifiedIndex
-            self._last_cluster_view = cluster_view.copy()
 
         except etcd.EtcdKeyError:
             # If the key doesn't exist in etcd then there is currently no
@@ -287,6 +286,7 @@ class EtcdSynchronizer(object):
             # The main loop (which reads from etcd in a loop) should call this
             # function again after we return, causing the read to be retried.
 
+        self._last_cluster_view = cluster_view.copy()
         return cluster_view
 
     # Write the new cluster view to etcd. We may be expecting to create the key

--- a/src/metaswitch/clearwater/cluster_manager/plugin_loader.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_loader.py
@@ -51,5 +51,7 @@ def load_plugins_in_dir(dir, *config):
             if file:
                 mod = imp.load_module(module_name, file, pathname, description)
                 if hasattr(mod, "load_as_plugin"):
-                    plugins.append(mod.load_as_plugin(*config))
+                    plugin = mod.load_as_plugin(*config)
+                    if plugin:
+                        plugins.append(plugin)
     return plugins


### PR DESCRIPTION
This fixes the issue you were seeing on Sprout - the etcd key for the remote memcached site didn't exist, and we didn't set the last cluster view in this case, so we always saw that the last view (None) didn't match the result ({}) and kept reading in a loop. (In any other plugin, we'd have moved ourself into the cluster and this wouldn't have happened, but remote memcached is special.)

I'm not sure this is the right fix - it might be nicer to have `load_as_plugin` for this plugin return None if the remote site isn't set (and for the plugin loader to spot that). I'll mull it over, but this unblocks you.