### PR TITLE
[Reviewer: Ellie] Update check_cluster_health to work again and support GR

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ue
+
+. /etc/clearwater/config
+
+if [ $# -ne 0 ]
+then
+  echo "Usage: check_cluster_health"
+  exit 1
+fi
+
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health.py $local_ip $local_site_name $remote_site_name


### PR DESCRIPTION
Tested a version of this live, output:

```
Describing sprout memcached cluster in site odd_numbers:
  Local node is in this cluster
  Cluster is healthy and stable
   10.101.147.26 is in state normal

Describing sprout memcached cluster in site even_numbers:
  Local node is *not* in this cluster
  Cluster is healthy and stable
   10.7.139.4 is in state normal

Describing sprout chronos cluster in site odd_numbers:
  Local node is in this cluster
  Cluster is healthy and stable
   10.101.147.26 is in state normal
```

It doesn't work with Cassandra yet - I'd agreed with Andy to add a /clearwater/ prefix to the keys, but haven't done that for Homestead/Memento's Cassandra plugins. I'll fix those plugins up.