### PR TITLE
[Reviewer: Rob] Add a wrapper script around etcdctl

### DIFF
--- a/clearwater-etcd/usr/bin/clearwater-etcdctl
+++ b/clearwater-etcd/usr/bin/clearwater-etcdctl
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+. /etc/clearwater/config
+
+# Work out the IP address to contact etcd on. Look first for
+# management_local_ip and fall back to local_ip.
+target_ip=$management_local_ip
+[ -z "$target_ip" ] && target_ip=$local_ip
+
+if [ -z "$target_ip" ]; then
+  echo "Could not determine local IP address"
+  exit 1
+fi
+
+# Run the real etcdctl.
+etcdctl -C $target_ip:4000 "$@"


### PR DESCRIPTION
Rob, please can you review this change to add a wrapper script around etcdctl that fills in the local IP based on /etc/clearwater/config. 

I've tested this by running `clearwater-etcdctl member list` when:

* `local_ip` was set up correctly. 
* `local_ip` was wrong but `management_local_ip` was correct.

Both times the script returned the expected output. 