### PR TITLE
[Reviewer: Andy] Clean up logging

### DIFF
--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -84,7 +84,7 @@ do_start()
         local_site_name=site1
         remote_site_name=""
         . /etc/clearwater/config
-        log_level=2
+        log_level=3
         log_directory=/var/log/clearwater-cluster-manager
         [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -96,6 +96,13 @@ def main(args):
         utils.daemonize(stdout_err_log)
 
     logging_config.configure_logging(log_level, log_dir, "cluster-manager")
+
+    # urllib3 logs a WARNING log whenever it recreates a connection, but our
+    # etcd usage does this frequently (to allow watch timeouts), so deliberately
+    # ignore this log
+    urllib_logger = logging.getLogger('connectionpool.py')
+    urllib_logger.setLevel(logging.ERROR)
+
     utils.install_sigusr1_handler("cluster-manager")
 
     # Drop a pidfile.

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -100,7 +100,7 @@ def main(args):
     # urllib3 logs a WARNING log whenever it recreates a connection, but our
     # etcd usage does this frequently (to allow watch timeouts), so deliberately
     # ignore this log
-    urllib_logger = logging.getLogger('connectionpool.py')
+    urllib_logger = logging.getLogger('urllib3')
     urllib_logger.setLevel(logging.ERROR)
 
     utils.install_sigusr1_handler("cluster-manager")


### PR DESCRIPTION
This:
 * logs at INFO level by default, as originally specced
 * suppresses urllib3 WARNING logs, which are currently a bit spammy (I can see why - connections aren't closed when they time out, so a connection with a pending response gets reused and immediately fails - but we'll have to submit a patch to urllib3 to fix it properly)