### PR TITLE
[Reviewer: Alex] Make mark_node_failed script more usable

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
@@ -2,15 +2,17 @@
 
 set -ue
 
+local_site_name=site1
 . /etc/clearwater/config
 
-if [ $# -ne 2 ]
+if [ $# -ne 3 ]
 then
-  echo "Usage: mark_node_failed [etcd_key] [failed_node_ip]"
+  echo "Usage: mark_node_failed [node_type] [datastore] [failed_node_ip]"
   exit 1
 fi
 
-key=$1
-dead_node_ip=$2
+node_type=$1
+datastore=$2
+dead_node_ip=$3
 
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py $local_ip $key $dead_node_ip
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py $local_ip $local_site_name $node_type $datastore $dead_node_ip

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
@@ -6,13 +6,24 @@ from metaswitch.clearwater.cluster_manager.null_plugin import \
 import etcd
 import logging
 
+def make_key(site, node_type, datatore):
+    if datastore == "cassandra":
+        return "/clearwater/{}/clustering/{}".format(node_type, datastore)
+    else:
+        return "/clearwater/{}/{}/clustering/{}".format(site, node_type, datastore)
 
 root_log = logging.getLogger()
 root_log.setLevel(logging.INFO)
 
 local_ip = sys.argv[1]
-key = sys.argv[2]
-dead_node_ip = sys.argv[3]
+site = sys.argv[2]
+node_type = sys.argv[3]
+datastore = sys.argv[4]
+dead_node_ip = sys.argv[5]
+
+key = make_key(site, node_type, datastore)
+print "Using etcd key %s" % (key)
+
 error_syncer = EtcdSynchronizer(NullPlugin(key), local_ip, etcd_ip=dead_node_ip, force_leave=True)
 error_syncer.mark_node_failed()
 

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
@@ -15,6 +15,12 @@ def make_key(site, node_type, datatore):
 root_log = logging.getLogger()
 root_log.setLevel(logging.INFO)
 
+ch = logging.StreamHandler(sys.stdout)
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+root_log.addHandler(ch)
+
 local_ip = sys.argv[1]
 site = sys.argv[2]
 node_type = sys.argv[3]
@@ -24,8 +30,18 @@ dead_node_ip = sys.argv[5]
 key = make_key(site, node_type, datastore)
 print "Using etcd key %s" % (key)
 
-error_syncer = EtcdSynchronizer(NullPlugin(key), local_ip, etcd_ip=dead_node_ip, force_leave=True)
+error_syncer = EtcdSynchronizer(NullPlugin(key), dead_node_ip, etcd_ip=local_ip, force_leave=True)
+
+# Move the dead node into ERROR state to allow in-progress operations to
+# complete
 error_syncer.mark_node_failed()
+
+# Move the dead node out of the cluster
+error_syncer.start_thread()
+error_syncer.leave_cluster()
+
+# Wait for it to leave
+error_syncer.thread.join()
 
 c = etcd.Client(local_ip, 4000)
 new_state = c.get(key).value

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -98,7 +98,7 @@ class EtcdSynchronizer(object):
                                            cluster_view)
 
             # If we have a new state, try and write it to etcd.
-            if new_state:
+            if new_state is not None:
                 self.write_to_etcd(cluster_view, new_state)
             else:
                 _log.debug("No state change")
@@ -117,6 +117,7 @@ class EtcdSynchronizer(object):
     def leave_cluster(self):
         result = self._client.get(self._key)
         cluster_view = self.parse_cluster_view(result.value)
+        self._index = result.modifiedIndex
 
         cluster_state = self.calculate_cluster_state(cluster_view)
 
@@ -129,6 +130,7 @@ class EtcdSynchronizer(object):
     def mark_node_failed(self):
         result = self._client.get(self._key)
         cluster_view = self.parse_cluster_view(result.value)
+        self._index = result.modifiedIndex
 
         self.write_to_etcd(cluster_view, ERROR)
 


### PR DESCRIPTION
Fixes #28. I'll test by installing on a node, running it, and checking ther dump_etcd_state output before and afterwards.