### PR TITLE
[Reviewer: Ellie] Default local_site_name in check_cluster_health

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health
@@ -2,6 +2,7 @@
 
 set -ue
 
+local_site_name=site1
 . /etc/clearwater/config
 
 if [ $# -ne 0 ]


### PR DESCRIPTION
I've run `grep -r "local_site_name" src/ clearwater-cluster-manager.root/ debian/*.init.d` to check that every script that uses it also defaults it.