### PR TITLE
[Reviewer: Andy] Cope with the case where init.d is in place but the Python virtualenv…

### DIFF
--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -57,6 +57,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
+[ -x $ACTUAL_EXEC ] || exit 0
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME


### PR DESCRIPTION
… isn't

If you upgrade a deployment, the Sprout upgrade can sometimes print "start-stop-daemon: unable to stat /usr/share/clearwater/clearwater-cluster-manager/env/bin/python (No such file or directory)". This is because clearwater-cluster-manager deletes its virtualenv when preparing for upgrade (but leaves init.d in place), and the Sprout upgrade can try and restart clearwater-cluster-manager before the virtualenv has been recreated.

This check should suppress that warning (which is benign anyway, as clearwater-cluster-manager starts up once it is upgraded, so Sprout failing to restart it doesn't matter).