### PR TITLE
[Reviewer: Matt] Add config-management meta-package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON_BIN := $(shell which python)
 
 DEB_COMPONENT := clearwater-etcd
 DEB_MAJOR_VERSION := 1.0${DEB_VERSION_QUALIFIER}
-DEB_NAMES := clearwater-etcd clearwater-cluster-manager clearwater-config-manager
+DEB_NAMES := clearwater-etcd clearwater-cluster-manager clearwater-config-manager clearwater-management
 DEB_ARCH := all
 
 # The build has been seen to fail on Mac OSX when trying to build on i386. Enable this to build for x86_64 only

--- a/debian/control
+++ b/debian/control
@@ -22,4 +22,9 @@ Description: Cluster manager for Clearwater
 Package: clearwater-config-manager
 Architecture: all
 Depends: python-dev, python-pip, libffi-dev, libssl-dev, libzmq3-dev, python-virtualenv, clearwater-etcd
-Description: Cluster manager for Clearwater
+Description: Configuration manager for Clearwater
+
+Package: clearwater-management
+Architecture: all
+Depends: clearwater-cluster-manager (= ${source:Version}), clearwater-config-manager (= ${source:Version})
+Description: Meta-package for installing all Clearwater management services


### PR DESCRIPTION
This PR adds a new meta-package that depends on the cluster and config managers, so that operators only need to install one thing. 

Tested by:

* On a new system running `sudo apt-get install clearwater-management`. Both dependent packages got installed. 
* Doing a new build of this repo and running `sudo apt-get update && sudo apt-get install clearwater-management`. The meta-package and both dependent packages were upgraded. 