### PR TITLE
[Reviewer: Andy] Fix path to plugin_utils

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/plugins/shared_config_plugin.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/plugins/shared_config_plugin.py
@@ -31,7 +31,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 from metaswitch.clearwater.config_manager.plugin_base import ConfigPluginBase, FileStatus
-from metaswitch.clearwater.config_manager.plugin_utils import run_command
+from metaswitch.clearwater.etcd_shared.plugin_utils import run_command
 import logging
 import shutil
 import os


### PR DESCRIPTION
I picked up the latest code out of master and it didn't work.  It looks like `plugin_utils.py` has been moved into `etcd_shared`, but the references here and in sprout haven't been updated.