### PR TITLE
[Reviewer: Andy] Fix check_cluster_health script when running non-GR

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health
@@ -3,6 +3,7 @@
 set -ue
 
 local_site_name=site1
+remote_site_name=
 . /etc/clearwater/config
 
 if [ $# -ne 0 ]


### PR DESCRIPTION
`check_cluster_health` didn't work in a non-GR deployment because `remote_site_name` isn't set but `set -u` is (so bash considers accessing undefined variables as an error).