### PR TITLE
[Reviewer: Andy] Default local_site_name in upload_shared_config

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config
@@ -35,6 +35,7 @@
 FILENAME=/etc/clearwater/shared_config
 
 # Check we can contact `etcd`
+local_site_name=site1
 . /etc/clearwater/config
 if ! nc -z $local_ip 4000
 then

--- a/debian/clearwater-config-manager.init.d
+++ b/debian/clearwater-config-manager.init.d
@@ -79,6 +79,7 @@ do_start()
   #   2 if daemon could not be started
   [ -e /etc/clearwater/no_config_manager ] && (echo "/etc/clearwater/no_config_manager exists, not starting config manager" && return 2)
 
+  local_site_name=site1
   . /etc/clearwater/config
   log_level=3
   log_directory=/var/log/clearwater-config-manager


### PR DESCRIPTION
`upload_shared_config` is missing a `local_site_name`.  Fix is to default it as we do everywhere else.