### PR TITLE
Reviewer Alex - Load plugin_utils from etcd_shared, not config_manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.eggs/
 /cluster_mgr_eggs/
 /config_mgr_eggs/
 /_env/

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync.py
@@ -32,7 +32,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-from metaswitch.clearwater.config_manager.plugin_loader import load_plugins_in_dir
+from metaswitch.clearwater.etcd_shared.plugin_loader import load_plugins_in_dir
 from metaswitch.clearwater.config_manager.plugin_base import FileStatus
 import etcd
 import os


### PR DESCRIPTION
You saw this earlier today (and saw me put in this very fix).