### PR TITLE
[Reviewer: Andy] Iss33

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -95,8 +95,8 @@ class EtcdSynchronizer(object):
                 else:
                     local_state = self.calculate_local_state(cluster_view)
                     new_state = self._fsm.next(local_state,
-                                            cluster_state,
-                                            cluster_view)
+                                               cluster_state,
+                                               cluster_view)
 
                 # If we have a new state, try and write it to etcd.
                 if new_state is not None:
@@ -241,9 +241,10 @@ class EtcdSynchronizer(object):
             if cluster_view == self._last_cluster_view:
                 while not self._terminate_flag and self._fsm.is_running():
                     try:
+                        _log.info("Watching for changes")
                         result = self._client.watch(self._key,
                                                     index=result.modifiedIndex+1,
-                                                    timeout=5,
+                                                    timeout=0,
                                                     recursive=False)
                         break
                     except urllib3.exceptions.TimeoutError:

--- a/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
@@ -32,12 +32,10 @@
 
 
 import logging
-import os
 import socket
 import time
 import yaml
 from textwrap import dedent
-import subprocess
 from metaswitch.clearwater.cluster_manager import constants
 from metaswitch.clearwater.etcd_shared.plugin_utils import run_command
 

--- a/src/metaswitch/clearwater/config_manager/__init__.py
+++ b/src/metaswitch/clearwater/config_manager/__init__.py
@@ -1,1 +1,0 @@
-from metaswitch.clearwater.etcd_shared import plugin_utils

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -82,9 +82,10 @@ class EtcdSynchronizer(object):
             if result.modifiedIndex == self._index:
                 while not self._terminate_flag:
                     try:
+                        _log.info("Watching for changes")
                         result = self._client.watch(full_key,
                                                     index=result.modifiedIndex+1,
-                                                    timeout=5,
+                                                    timeout=0,
                                                     recursive=False)
                         break
                     except urllib3.exceptions.TimeoutError:

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -31,7 +31,6 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 import etcd
-from threading import Thread
 from time import sleep
 
 import urllib3

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -61,7 +61,6 @@ from metaswitch.clearwater.config_manager.alarms \
 import logging
 import os
 from threading import Thread
-import signal
 
 _log = logging.getLogger("config_manager.main")
 


### PR DESCRIPTION
This means we don't use a timeout on etcd watches. Watching doesn't block termination, so we can just use an eternal watch. Tested live. 

I've also tidied up some flake8 warnings

Fixes #33 
