### PR TITLE
[Reviewer: Andy] Fix typo in cluster manager

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -104,7 +104,7 @@ class EtcdSynchronizer(object):
                 else:
                     _log.debug("No state change")
             else:
-                log.warning("read_from_etcd returned None, indicating a failure to get data from etcd")
+                _log.warning("read_from_etcd returned None, indicating a failure to get data from etcd")
 
         _log.info("Quitting FSM")
         self._fsm.quit()


### PR DESCRIPTION
A really simple fix to a typo in the cluster manager (that was causing the cluster manager to crash).