### PR TITLE
[Reviewer: Andy] Enable cassandra clustering to cope with multiple networks. 

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster
@@ -46,4 +46,4 @@ fi
 
 node_type=$1
 
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py "$local_ip" "$node_type"
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py "$local_ip" "$node_type" "$signaling_namespace"

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
@@ -6,6 +6,7 @@ import json
 
 local_ip = sys.argv[1]
 node_type = sys.argv[2]
+sig_namespace = sys.argv[3]
 
 assert node_type in ["homestead", "homer", "memento"], \
     "Node type must be 'homestead', 'homer' or 'memento'"
@@ -16,8 +17,11 @@ try:
     # Use nodetool describecluster to find the nodes in the existing cluster.
     # This returns a yaml document, but in order for pyyaml to recognise the
     # output as valid yaml, we need to use tr to replace tabs with spaces.
-    desc_cluster_output = subprocess.check_output(
-        "nodetool describecluster | tr \"\t\" \" \"", shell=True)
+    command = "nodetool describecluster | tr \"\t\" \" \""
+    if sig_namespace:
+        command = "ip netns exec {} ".format(sig_namespace) + command
+
+    desc_cluster_output = subprocess.check_output(command, shell=True)
     doc = yaml.load(desc_cluster_output)
     servers = doc["Cluster Information"]["Schema versions"].values()[0]
     data = json.dumps({server: "normal" for server in servers})

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/plugins/shared_config_plugin.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/plugins/shared_config_plugin.py
@@ -50,6 +50,9 @@ services = { "sprout": "quiesce",
 
 
 class SharedConfigPlugin(ConfigPluginBase):
+    def __init__(self, _params):
+        pass
+
     def key(self):
         return "shared_config"
 
@@ -91,5 +94,5 @@ class SharedConfigPlugin(ConfigPluginBase):
         except OSError:
             pass
 
-def load_as_plugin():
-    return SharedConfigPlugin()
+def load_as_plugin(params):
+    return SharedConfigPlugin(params)

--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -83,12 +83,19 @@ do_start()
 
   local_site_name=site1
   remote_site_name=""
+  signaling_namespace=""
   . /etc/clearwater/config
   log_level=3
   log_directory=/var/log/clearwater-cluster-manager
   [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 
-  DAEMON_ARGS="--local-ip=$local_ip --local-site=$local_site_name --remote-site=$remote_site_name --log-level=$log_level --log-directory=$log_directory --pidfile=$PIDFILE"
+  DAEMON_ARGS="--local-ip=$local_ip
+               --local-site=$local_site_name
+               --remote-site=$remote_site_name
+               --signaling-namespace=$signaling_namespace
+               --log-level=$log_level
+               --log-directory=$log_directory
+               --pidfile=$PIDFILE"
 
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
     || return 1

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -54,10 +54,9 @@ Options:
 from docopt import docopt
 
 from metaswitch.common import logging_config, utils
-from metaswitch.clearwater.etcd_shared.plugin_loader \
-    import load_plugins_in_dir
-from metaswitch.clearwater.cluster_manager.etcd_synchronizer \
-    import EtcdSynchronizer
+from metaswitch.clearwater.etcd_shared.plugin_loader import load_plugins_in_dir
+from metaswitch.clearwater.cluster_manager.etcd_synchronizer import EtcdSynchronizer
+from metaswitch.clearwater.cluster_manager.plugin_base import PluginParams
 import logging
 import os
 from threading import Thread
@@ -112,9 +111,10 @@ def main(args):
 
     plugins_dir = "/usr/share/clearwater/clearwater-cluster-manager/plugins/"
     plugins = load_plugins_in_dir(plugins_dir,
-                                  listen_ip,
-                                  local_site_name,
-                                  remote_site_name)
+                                  PluginParams(ip=listen_ip,
+                                               local_site=local_site_name,
+                                               remote_site=remote_site_name,
+                                               signaling_namespace=None))
     plugins.sort(key=lambda x: x.key())
     plugins_to_use = []
     files = []

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -36,14 +36,15 @@
 
 Usage:
   main.py --local-ip=IP --local-site=NAME --remote-site=NAME
-          [--foreground] [--log-level=LVL] [--log-directory=DIR]
-          [--pidfile=FILE]
+          [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
+          [--log-directory=DIR] [--pidfile=FILE]
 
 Options:
   -h --help                   Show this screen.
   --local-ip=IP               IP address
   --local-site=NAME           Name of local site
   --remote-site=NAME          Name of remote site
+  --signaling-namespace=NAME  Name of the signaling namespace
   --foreground                Don't daemonise
   --log-level=LVL             Level to log at, 0-4 [default: 3]
   --log-directory=DIR         Directory to log to [default: ./]
@@ -86,6 +87,7 @@ def main(args):
     listen_ip = arguments['--local-ip']
     local_site_name = arguments['--local-site']
     remote_site_name = arguments['--remote-site']
+    signaling_namespace = arguments.get('--signaling-namespace')
     log_dir = arguments['--log-directory']
     log_level = LOG_LEVELS.get(arguments['--log-level'], logging.DEBUG)
 
@@ -114,7 +116,7 @@ def main(args):
                                   PluginParams(ip=listen_ip,
                                                local_site=local_site_name,
                                                remote_site=remote_site_name,
-                                               signaling_namespace=None))
+                                               signaling_namespace=signaling_namespace))
     plugins.sort(key=lambda x: x.key())
     plugins_to_use = []
     files = []

--- a/src/metaswitch/clearwater/cluster_manager/plugin_base.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_base.py
@@ -1,4 +1,10 @@
 from abc import ABCMeta, abstractmethod
+import collections
+
+
+PluginParams = collections.namedtuple(
+                 'PluginParams',
+                 ['ip', 'local_site', 'remote_site', 'signaling_namespace'])
 
 
 class SynchroniserPluginBase(object):

--- a/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
@@ -141,7 +141,7 @@ def join_cassandra_cluster(cluster_view,
         _log.warning("No Cassandra cluster defined in etcd - unable to join")
 
 
-def leave_cassandra_cluster():
+def leave_cassandra_cluster(namespace=None):
     # We need Cassandra to be running so that we can connect on port 9160 and
     # decommission it. Check if we can connect on port 9160.
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -151,7 +151,7 @@ def leave_cassandra_cluster():
         start_cassandra()
 
     run_command("monit unmonitor -g cassandra")
-    run_command("nodetool decommission")
+    run_command("nodetool decommission", namespace)
 
 
 def start_cassandra():

--- a/src/metaswitch/clearwater/cluster_manager/test/contention_detecting_plugin.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/contention_detecting_plugin.py
@@ -41,8 +41,8 @@ class ContentionDetectingPlugin(SynchroniserPluginBase):
 
     This would mean that we were needlessly repeating work - our handling of
     etcd contention ought to avoid this."""
-    def __init__(self, ip):
-        self.ip = ip
+    def __init__(self, params):
+        self.ip = params.ip
         self.on_cluster_changing_nodes = []
         self.on_joining_nodes = []
         self.on_new_cluster_config_ready_nodes = []

--- a/src/metaswitch/clearwater/cluster_manager/test/dummy_plugin.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/dummy_plugin.py
@@ -38,7 +38,7 @@ _log = logging.getLogger("example_plugin")
 
 
 class DummyPlugin(SynchroniserPluginBase):
-    def __init__(self, ip):
+    def __init__(self, params):
         _log.debug("Raising not-clustered alarm")
 
     def key(self):

--- a/src/metaswitch/clearwater/cluster_manager/test/fail_partway_through_plugin.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/fail_partway_through_plugin.py
@@ -37,7 +37,7 @@ _log = logging.getLogger("example_plugin")
 
 
 class FailPlugin(SynchroniserPluginBase):
-    def __init__(self, ip):
+    def __init__(self, params):
         _log.debug("Raising not-clustered alarm")
 
     def key(self):

--- a/src/metaswitch/clearwater/cluster_manager/test/plugins/plugin_loader_test_plugin.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/plugins/plugin_loader_test_plugin.py
@@ -39,7 +39,7 @@ _log = logging.getLogger("example_plugin")
 
 
 class PluginLoaderTestPlugin(SynchroniserPluginBase):
-    def __init__(self, ip):
+    def __init__(self, params):
         pass
 
     def key(self):
@@ -61,5 +61,5 @@ class PluginLoaderTestPlugin(SynchroniserPluginBase):
     def on_leaving_cluster(self, cluster_view):
         _log.info("I'm out of the cluster")
 
-def load_as_plugin(x):
-    return PluginLoaderTestPlugin(x)
+def load_as_plugin(params):
+    return PluginLoaderTestPlugin(params)

--- a/src/metaswitch/clearwater/etcd_shared/plugin_loader.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_loader.py
@@ -37,7 +37,7 @@ import os
 
 _log = logging.getLogger("etcd_shared.plugin_loader")
 
-def load_plugins_in_dir(dir, *optional_config):
+def load_plugins_in_dir(dir, params=None):
     """Loads plugins by:
         - looking for all .py files in the given directory
         - calling their load_as_plugin() function
@@ -54,7 +54,7 @@ def load_plugins_in_dir(dir, *optional_config):
             if file:
                 mod = imp.load_module(module_name, file, pathname, description)
                 if hasattr(mod, "load_as_plugin"):
-                    plugin = mod.load_as_plugin(*optional_config)
+                    plugin = mod.load_as_plugin(params)
                     _log.info("Loading {}".format(filename))
                     if plugin is not None:
                         _log.info("Loaded {} successfully".format(filename))

--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -37,13 +37,18 @@ import logging
 _log = logging.getLogger("etcd_shared.plugin_utils")
 
 
-def run_command(command):
+def run_command(command, namespace=None):
     """Runs the given shell command, logging the output and return code.
+
+    If a namespace is supplied the command is run in the specified namespace.
 
     Note that this runs the provided command in a new shell, which will
     apply shell replacements.  Ensure the input string is sanitized before
     passing to this function.
     """
+    if namespace:
+        command += "ip netns exec {} ".format(namespace) + command
+
     try:
         output = subprocess.check_output(command,
                                          shell=True,


### PR DESCRIPTION
Andy please can you review this PR that allows clustering to work with multiple networks. 

The bulk of the PR is refactoring so plugins are passed parameters in a class object rather than one by one. - this will make it easier to add new parameters in future. Using this new framework, the cluster-manager now passes plugins the signaling namespace which the Cassandra plugins can use to decommission Cassandra. 

I have tested this as follows:

* Created a FT deployment, and checked that all nodes were clustered together (using `check_cluster_health`) and all nodes had the shared config. 
* Successfully decommissioned a homestead node (that did not use multiple networks). 
* On a homer node I set up an aliased network namespace and set that as `signaling_namespace`. Then I successfully decommissioned the node. 
* Hacked `load_from_cassandra_cluster` to print the result of `nodetool describecluster` and ran it on those two nodes. 