### PR TITLE
Reviewer Ellie - Kill the Cassandra PID in case service stop doesn't work

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_utils.py
@@ -125,6 +125,7 @@ def join_cassandra_cluster(cluster_view,
         _log.debug("Restarting Cassandra")
         run_command("monit unmonitor -g cassandra")
         run_command("service cassandra stop")
+        run_command("killall $(cat /var/lib/cassandra/cassandra.pid")
         run_command("rm -rf /var/lib/cassandra/")
         run_command("mkdir -m 755 /var/lib/cassandra")
         run_command("chown -R cassandra /var/lib/cassandra")


### PR DESCRIPTION
Easy fix for Cassandra not dying, I've not managed to repro the failure with or without this fix, but this should always be safe.

Fixes https://github.com/Metaswitch/clearwater-cassandra/issues/27.