### PR TITLE
[Reviewer: Ellie] Actually exit if no_cluster_manager exists

### DIFF
--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -79,7 +79,11 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
 
-  [ -e /etc/clearwater/no_cluster_manager ] && (echo "/etc/clearwater/no_cluster_manager exists, not starting cluster manager" && return 2)
+  if [ -e /etc/clearwater/no_cluster_manager ]
+  then
+    echo "/etc/clearwater/no_cluster_manager exists, not starting cluster manager"
+    return 2
+  fi
 
   local_site_name=site1
   remote_site_name=""


### PR DESCRIPTION
My cool one-liner with &&s somehow meant that "return 2" didn't take effect.

Tested as follows:

```
[ralf-1]ubuntu@ec2-54-160-232-37:~$ cat test_ncm.sh
do_start() {
  if [ -e /etc/clearwater/no_cluster_manager ]
  then
    echo "/etc/clearwater/no_cluster_manager exists, not starting cluster manager"
    return 2
  fi
  echo "abcd"
}

do_start
[ralf-1]ubuntu@ec2-54-160-232-37:~$ bash test_ncm.sh
/etc/clearwater/no_cluster_manager exists, not starting cluster manager
[ralf-1]ubuntu@ec2-54-160-232-37:~$
```