### PR TITLE
[Reviewer: Andy] Change easy_install command to be more precise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ cluster-mgr-build-eggs: cluster_mgr_setup.py shared_setup.py common/setup.py src
 .PHONY: install-eggs
 install-eggs: cluster_mgr_eggs config_mgr_eggs
 	# Install the downloaded egg files (this should match the Debian postinst)
-	${ENV_DIR}/bin/easy_install --allow-hosts=None -f cluster_mgr_eggs/ cluster_mgr_eggs/*.egg
-	${ENV_DIR}/bin/easy_install --allow-hosts=None -f config_mgr_eggs/ config_mgr_eggs/*.egg
+	${ENV_DIR}/bin/easy_install --allow-hosts=None -f cluster_mgr_eggs/ cluster_mgr_eggs/clearwater_cluster_manager-1.0-py2.7.egg
+	${ENV_DIR}/bin/easy_install --allow-hosts=None -f config_mgr_eggs/ config_mgr_eggs/clearwater_config_manager-1.0-py2.7.egg
 
 .PHONY: deb
 deb: env build-eggs deb-only

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ config-mgr-build-eggs: config_mgr_setup.py shared_setup.py common/setup.py src
 	cd common && ${ENV_DIR}/bin/python setup.py bdist_egg -d ../config_mgr_eggs
 
 	# Download the egg files they depend upon
-	${ENV_DIR}/bin/easy_install -zmaxd config_mgr_eggs/ config_mgr_eggs/*.egg
+	${ENV_DIR}/bin/easy_install -zmaxd config_mgr_eggs/ config_mgr_eggs/clearwater_config_manager-1.0-py2.7.egg
+	${ENV_DIR}/bin/easy_install -zmaxd config_mgr_eggs/ config_mgr_eggs/clearwater_etcd_shared-1.0-py2.7.egg
+	${ENV_DIR}/bin/easy_install -zmaxd config_mgr_eggs/ config_mgr_eggs/metaswitchcommon-0.1-py2.7.egg
 
 .PHONY: build-eggs
 build-eggs: cluster-mgr-build-eggs config-mgr-build-eggs
@@ -71,7 +73,9 @@ cluster-mgr-build-eggs: cluster_mgr_setup.py shared_setup.py common/setup.py src
 	cd common && ${ENV_DIR}/bin/python setup.py bdist_egg -d ../cluster_mgr_eggs
 
 	# Download the egg files they depend upon
-	${ENV_DIR}/bin/easy_install -zmaxd cluster_mgr_eggs/ cluster_mgr_eggs/*.egg
+	${ENV_DIR}/bin/easy_install -zmaxd cluster_mgr_eggs/ cluster_mgr_eggs/clearwater_cluster_manager-1.0-py2.7.egg
+	${ENV_DIR}/bin/easy_install -zmaxd cluster_mgr_eggs/ cluster_mgr_eggs/clearwater_etcd_shared-1.0-py2.7.egg
+	${ENV_DIR}/bin/easy_install -zmaxd cluster_mgr_eggs/ cluster_mgr_eggs/metaswitchcommon-0.1-py2.7.egg
 
 .PHONY: install-eggs
 install-eggs: cluster_mgr_eggs config_mgr_eggs

--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.cluster_manager.test',
-    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml"],
+    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["Mock"],
     )

--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -47,6 +47,6 @@ setup(
     package_data={
         '': ['*.eml'],
         },
-    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml"],
+    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["Mock"],
     )

--- a/debian/clearwater-cluster-manager.postinst
+++ b/debian/clearwater-cluster-manager.postinst
@@ -63,7 +63,7 @@ case "$1" in
         chown -R $NAME:root /var/log/$NAME
 
         virtualenv --python=$(which python) $BASE_DIR/env
-        $BASE_DIR/env/bin/easy_install --allow-hosts=None -f $BASE_DIR/eggs/ $BASE_DIR/eggs/*.egg
+        $BASE_DIR/env/bin/easy_install --allow-hosts=None -f $BASE_DIR/eggs/ $BASE_DIR/eggs/clearwater_cluster_manager-1.0-py2.7.egg
         chown -R $NAME:root $BASE_DIR/env
         
         mkdir -p $BASE_DIR/plugins

--- a/debian/clearwater-config-manager.postinst
+++ b/debian/clearwater-config-manager.postinst
@@ -63,7 +63,7 @@ case "$1" in
         chown -R $NAME:root /var/log/$NAME
 
         virtualenv --python=$(which python) $BASE_DIR/env
-        $BASE_DIR/env/bin/easy_install --allow-hosts=None -f $BASE_DIR/eggs/ $BASE_DIR/eggs/*.egg
+        $BASE_DIR/env/bin/easy_install --allow-hosts=None -f $BASE_DIR/eggs/ $BASE_DIR/eggs/clearwater_config_manager-1.0-py2.7.egg
         chown -R $NAME:root $BASE_DIR/env
 
         mkdir -p $BASE_DIR/plugins


### PR DESCRIPTION
Fixes #81 - this means we install the .egg file we want, which pulls in the other dependencies, rather than installing every .egg file in the directory.

Tested on a 14.04 node by confirming that `git clone -b 1404_fix --recursive https://github.com/Metaswitch/clearwater-etcd.git iss81_test && cd iss81_test && make deb` works and `git clone --recursive https://github.com/Metaswitch/clearwater-etcd.git iss81_test_2 && cd iss81_test_2 && make deb` consistently fails.