### PR TITLE
[Reviewer: Ellie] Fix quitting

### DIFF
--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.cluster_manager.test',
-    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "futures", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["Mock"],
     )

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -258,6 +258,10 @@ class EtcdSynchronizer(object):
                 while not self._terminate_flag and self._fsm.is_running():
                     try:
                         _log.info("Watching for changes")
+                        # Use a concurrent.futures.Executor to run the etcd poll
+                        # asynchronously. This means that, if we're told to quit
+                        # before etcd returns, we'll spot that we've been told
+                        # to quit and do so.
                         result_future = self.executor.submit(self._client.read,
                                                              self._key,
                                                              wait=True,

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -119,6 +119,10 @@ class EtcdSynchronizer(object):
     # a stable state, in which case we can leave. Otherwise, set a flag and
     # leave at the next available opportunity.
     def leave_cluster(self):
+        if not self._plugin.should_be_in_cluster():
+            # We're just monitoring this cluster, not in it, so leaving is a
+            # no-op
+            return
         result = self._client.read(self._key, quorum=True)
         cluster_view = self.parse_cluster_view(result.value)
         self._index = result.modifiedIndex
@@ -132,6 +136,10 @@ class EtcdSynchronizer(object):
             self._leaving_flag = True
 
     def mark_node_failed(self):
+        if not self._plugin.should_be_in_cluster():
+            # We're just monitoring this cluster, not in it, so leaving is a
+            # no-op
+            return
         result = self._client.read(self._key, quorum=True)
         cluster_view = self.parse_cluster_view(result.value)
         self._index = result.modifiedIndex
@@ -246,7 +254,7 @@ class EtcdSynchronizer(object):
                                                    wait=True,
                                                    waitIndex=result.modifiedIndex+1,
                                                    timeout=0,
-                                                   recursive=False, 
+                                                   recursive=False,
                                                    quorum=True)
                         break
                     except urllib3.exceptions.TimeoutError:

--- a/src/metaswitch/clearwater/cluster_manager/test/mock_python_etcd.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/mock_python_etcd.py
@@ -89,7 +89,7 @@ class MockEtcdClient(object):
         global_condvar.release()
         return self.fake_result()
 
-    def read(self, key, index=None, timeout=None, recursive=None, quorum=True):
+    def read(self, key, index=None, timeout=None, recursive=None, quorum=True, **kwargs):
         assert(key == allowed_key)
         global_condvar.acquire()
         if global_index == 0:


### PR DESCRIPTION
Catches SIGTERMs and shuts plugins down appropriately, and makes sure that we don't wait forever when we get a SIGTERM in the middle of an etcd watch.

Tested by:
* installing clearwater-cluster-manager on Ellis and checking it doesn't constantly restart
* running `service clearwater-cluster-manager stop` on Sprout and confirming (from the logs) that it exited cleanly and quickly

Fixes #33 and #37.