### PR TITLE
[Reviewer: Ellie] Add ENT logs to cluster-manager and config-manager

### DIFF
--- a/clearwater-etcd/usr/bin/etcdwrapper
+++ b/clearwater-etcd/usr/bin/etcdwrapper
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Tiny wrapper script to redirect etcd's stdout and stderr to a file
+# Tiny wrapper script to redirect etcd's stdout and stderr to a file and raise appropriate ENT logs
 
-/usr/share/clearwater/bin/ent_log.py CL_ETCD_STARTED
+/usr/share/clearwater/bin/ent_log.py "etcd" CL_ETCD_STARTED
 exec /usr/bin/etcd $@ >> /var/log/clearwater-etcd/clearwater-etcd.log 2>&1
-/usr/share/clearwater/bin/ent_log.py CL_ETCD_EXITED
+/usr/share/clearwater/bin/ent_log.py "etcd" CL_ETCD_EXITED

--- a/clearwater-etcd/usr/bin/etcdwrapper
+++ b/clearwater-etcd/usr/bin/etcdwrapper
@@ -2,4 +2,6 @@
 
 # Tiny wrapper script to redirect etcd's stdout and stderr to a file
 
+/usr/share/clearwater/bin/ent_log.py CL_ETCD_STARTED
 exec /usr/bin/etcd $@ >> /var/log/clearwater-etcd/clearwater-etcd.log 2>&1
+/usr/share/clearwater/bin/ent_log.py CL_ETCD_EXITED

--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
@@ -38,11 +38,4 @@
 # checking that the 4000 port is open.
 . /etc/clearwater/config
 /usr/share/clearwater/bin/poll-tcp 4000 $local_ip
-ret=$?
-
-if [ $ret != 0 ]
-then
-  /usr/share/clearwater/bin/ent_log.py "etcd" CL_ETCD_POLL_FAILED
-fi
-
-exit $ret
+exit $?

--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
@@ -42,7 +42,7 @@ ret=$?
 
 if [ $ret != 0 ]
 then
-  /usr/share/clearwater/bin/ent_log.py CL_ETCD_POLL_FAILED
+  /usr/share/clearwater/bin/ent_log.py "etcd" CL_ETCD_POLL_FAILED
 fi
 
 exit $ret

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -58,6 +58,7 @@ from metaswitch.common import logging_config, utils
 from metaswitch.clearwater.etcd_shared.plugin_loader import load_plugins_in_dir
 from metaswitch.clearwater.cluster_manager.etcd_synchronizer import EtcdSynchronizer
 from metaswitch.clearwater.cluster_manager.plugin_base import PluginParams
+from metaswitch.clearwater.cluster_manager.pdlogs import STARTUP, EXITING
 import logging
 import os
 import sys
@@ -97,6 +98,7 @@ def install_sigterm_handler(plugins):
     signal.signal(signal.SIGTERM, sigterm_handler)
 
 def main(args):
+    STARTUP.log()
     arguments = docopt(__doc__, argv=args)
 
     listen_ip = arguments['--local-ip']
@@ -170,6 +172,7 @@ def main(args):
         sleep(1)
     _log.info("Quitting")
     _log.debug("%d threads outstanding at exit" % activeCount())
+    EXITING.log()
     # Use os.exit to skip exit handlers - otherwise the concurrent.futures exit
     # handler waits for an infinite wait to end
     os._exit(0)

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -62,6 +62,7 @@ from metaswitch.clearwater.cluster_manager import pdlogs
 import logging
 import os
 import sys
+import syslog
 from threading import Thread, activeCount
 from time import sleep
 import signal
@@ -100,9 +101,8 @@ def install_sigterm_handler(plugins):
 def main(args):
     syslog.openlog("cluster-manager", syslog.LOG_PID)
     pdlogs.STARTUP.log()
-    arguments = {}
     try:
-        docopt(__doc__, argv=args)
+        arguments = docopt(__doc__, argv=args)
     except DocoptExit:
         pdlogs.EXITING_BAD_CONFIG.log()
         raise

--- a/src/metaswitch/clearwater/cluster_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/cluster_manager/pdlogs.py
@@ -30,7 +30,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-from metaswitch.common.pdlog import PDLog
+from metaswitch.common.pdlogs import PDLog
 
 STARTUP = PDLog(desc="clearwater-cluster-manager has started",
                 cause="The application is starting",
@@ -43,12 +43,12 @@ EXITING = PDLog(desc="clearwater-cluster-manager is exiting",
                 action="???",
                 priority=PDLog.LOG_NOTICE)
 NODE_JOINING = PDLog(desc="A node is joining a datastore cluster",
-                     cause="Node {ip} has started to join the {cluster_description} cluster",
+                     cause="Node {ip} has started to join the {cluster_desc}",
                      effect="Normal",
                      action="None",
                      priority=PDLog.LOG_NOTICE)
 NODE_LEAVING = PDLog(desc="A node is leaving a datastore cluster",
-                     cause="Node {ip} has started to leave the {cluster_description} cluster",
+                     cause="Node {ip} has started to leave the {cluster_desc}",
                      effect="Normal",
                      action="None",
                      priority=PDLog.LOG_NOTICE)

--- a/src/metaswitch/clearwater/cluster_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/cluster_manager/pdlogs.py
@@ -32,34 +32,40 @@
 
 from metaswitch.common.pdlogs import PDLog
 
-STARTUP = PDLog(desc="clearwater-cluster-manager has started",
+STARTUP = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+1,
+                desc="clearwater-cluster-manager has started",
                 cause="The application is starting",
                 effect="Normal",
                 action="None",
                 priority=PDLog.LOG_NOTICE)
-EXITING = PDLog(desc="clearwater-cluster-manager is exiting",
+EXITING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+2,
+                desc="clearwater-cluster-manager is exiting",
                 cause="The application is exiting",
                 effect="Datastore cluster management services are no longer available",
                 action="This occurs normally when the application is stopped. Wait for monit to restart the application",
                 priority=PDLog.LOG_ERR)
-EXITING_BAD_CONFIG = PDLog(desc="clearwater-cluster-manager is exiting due to bad configuration",
+EXITING_BAD_CONFIG = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+3,
+                           desc="clearwater-cluster-manager is exiting due to bad configuration",
                            cause="clearwater-cluster-manager was started with incorrect configuration",
                            effect="Datastore cluster management services are no longer available",
                            action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level, local_site_name and remote_site_name are set correctly.",
                            priority=PDLog.LOG_ERR)
-NODE_JOINING = PDLog(desc="A node is joining a datastore cluster",
+NODE_JOINING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+4,
+                     desc="A node is joining a datastore cluster",
                      cause="Node {ip} has started to join the {cluster_desc}",
                      effect="Normal",
                      action="None",
                      priority=PDLog.LOG_NOTICE)
-NODE_LEAVING = PDLog(desc="A node is leaving a datastore cluster",
+NODE_LEAVING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+5,
+                     desc="A node is leaving a datastore cluster",
                      cause="Node {ip} has started to leave the {cluster_desc}",
                      effect="Normal",
                      action="None",
                      priority=PDLog.LOG_NOTICE)
 
 NOT_YET_CLUSTERED_ALARM = \
-    PDLog(desc="This node is not yet clustered",
+    PDLog(number=PDLog.CL_CLUSTER_MGR_ID+6,
+          desc="This node is not yet clustered",
           cause="This node has not yet joined the {cluster_description} cluster",
           effect="This node will alarm until the cluster is joined",
           action="Wait for this node to join the cluster. If this "+\
@@ -69,7 +75,8 @@ NOT_YET_CLUSTERED_ALARM = \
           priority=PDLog.LOG_ERR)
 
 TOO_LONG_ALARM = \
-    PDLog(desc="A scaling operation has taken too long",
+    PDLog(number=PDLog.CL_CLUSTER_MGR_ID+7,
+          desc="A scaling operation has taken too long",
           cause="A scaling operation for the {cluster_description} cluster has been in progress for more than 15 minutes.",
           effect="This node will alarm until the operation finishes. No further scaling operations can begin until this one completes.",
           action="Ensure that clearwater-etcd is running, and fix any errors relating to it. If any nodes are temporarily failed, recover them. If any nodes are permanently failed, follow the documentation to remove them from the cluster.",

--- a/src/metaswitch/clearwater/cluster_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/cluster_manager/pdlogs.py
@@ -37,6 +37,11 @@ STARTUP = PDLog(desc="clearwater-cluster-manager has started",
                 effect="Normal",
                 action="None",
                 priority=PDLog.LOG_NOTICE)
+EXITING = PDLog(desc="clearwater-cluster-manager is exiting",
+                cause="The application is exiting",
+                effect="???",
+                action="???",
+                priority=PDLog.LOG_NOTICE)
 NODE_JOINING = PDLog(desc="A node is joining a datastore cluster",
                      cause="Node {ip} has started to join the {cluster_description} cluster",
                      effect="Normal",

--- a/src/metaswitch/clearwater/cluster_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/cluster_manager/pdlogs.py
@@ -39,9 +39,14 @@ STARTUP = PDLog(desc="clearwater-cluster-manager has started",
                 priority=PDLog.LOG_NOTICE)
 EXITING = PDLog(desc="clearwater-cluster-manager is exiting",
                 cause="The application is exiting",
-                effect="???",
-                action="???",
-                priority=PDLog.LOG_NOTICE)
+                effect="Datastore cluster management services are no longer available",
+                action="This occurs normally when the application is stopped. Wait for monit to restart the application",
+                priority=PDLog.LOG_ERR)
+EXITING_BAD_CONFIG = PDLog(desc="clearwater-cluster-manager is exiting due to bad configuration",
+                           cause="clearwater-cluster-manager was started with incorrect configuration",
+                           effect="Datastore cluster management services are no longer available",
+                           action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level, local_site_name and remote_site_name are set correctly.",
+                           priority=PDLog.LOG_ERR)
 NODE_JOINING = PDLog(desc="A node is joining a datastore cluster",
                      cause="Node {ip} has started to join the {cluster_desc}",
                      effect="Normal",

--- a/src/metaswitch/clearwater/cluster_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/cluster_manager/pdlogs.py
@@ -1,0 +1,66 @@
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+from metaswitch.common.pdlog import PDLog
+
+STARTUP = PDLog(desc="clearwater-cluster-manager has started",
+                cause="The application is starting",
+                effect="Normal",
+                action="None",
+                priority=PDLog.LOG_NOTICE)
+NODE_JOINING = PDLog(desc="A node is joining a datastore cluster",
+                     cause="Node {ip} has started to join the {cluster_description} cluster",
+                     effect="Normal",
+                     action="None",
+                     priority=PDLog.LOG_NOTICE)
+NODE_LEAVING = PDLog(desc="A node is leaving a datastore cluster",
+                     cause="Node {ip} has started to leave the {cluster_description} cluster",
+                     effect="Normal",
+                     action="None",
+                     priority=PDLog.LOG_NOTICE)
+
+NOT_YET_CLUSTERED_ALARM = \
+    PDLog(desc="This node is not yet clustered",
+          cause="This node has not yet joined the {cluster_description} cluster",
+          effect="This node will alarm until the cluster is joined",
+          action="Wait for this node to join the cluster. If this "+\
+          "does not happen, ensure that clearwater-etcd and "+\
+          "clearwater-cluster-manager have started up, and "+\
+          "fix any other errors relating to them.",
+          priority=PDLog.LOG_ERR)
+
+TOO_LONG_ALARM = \
+    PDLog(desc="A scaling operation has taken too long",
+          cause="A scaling operation for the {cluster_description} cluster has been in progress for more than 15 minutes.",
+          effect="This node will alarm until the operation finishes. No further scaling operations can begin until this one completes.",
+          action="Ensure that clearwater-etcd is running, and fix any errors relating to it. If any nodes are temporarily failed, recover them. If any nodes are permanently failed, follow the documentation to remove them from the cluster.",
+          priority=PDLog.LOG_ERR)

--- a/src/metaswitch/clearwater/cluster_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/cluster_manager/pdlogs.py
@@ -32,52 +32,61 @@
 
 from metaswitch.common.pdlogs import PDLog
 
-STARTUP = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+1,
-                desc="clearwater-cluster-manager has started.",
-                cause="The application is starting.",
-                effect="Normal.",
-                action="None.",
-                priority=PDLog.LOG_NOTICE)
-EXITING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+2,
-                desc="clearwater-cluster-manager is exiting.",
-                cause="The application is exiting.",
-                effect="Datastore cluster management services are no longer available.",
-                action="This occurs normally when the application is stopped. Wait for monit to restart the application.",
-                priority=PDLog.LOG_ERR)
-EXITING_BAD_CONFIG = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+3,
-                           desc="clearwater-cluster-manager is exiting due to bad configuration.",
-                           cause="clearwater-cluster-manager was started with incorrect configuration.",
-                           effect="Datastore cluster management services are no longer available.",
-                           action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level, local_site_name and remote_site_name are set correctly.",
-                           priority=PDLog.LOG_ERR)
-NODE_JOINING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+4,
-                     desc="A node is joining a datastore cluster.",
-                     cause="Node {ip} has started to join the {cluster_desc}.",
-                     effect="Normal.",
-                     action="None.",
-                     priority=PDLog.LOG_NOTICE)
-NODE_LEAVING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+5,
-                     desc="A node is leaving a datastore cluster.",
-                     cause="Node {ip} has started to leave the {cluster_desc}.",
-                     effect="Normal.",
-                     action="None.",
-                     priority=PDLog.LOG_NOTICE)
+STARTUP = PDLog(
+    number=PDLog.CL_CLUSTER_MGR_ID+1,
+    desc="clearwater-cluster-manager has started.",
+    cause="The application is starting.",
+    effect="Normal.",
+    action="None.",
+    priority=PDLog.LOG_NOTICE)
+EXITING = PDLog(
+    number=PDLog.CL_CLUSTER_MGR_ID+2,
+    desc="clearwater-cluster-manager is exiting.",
+    cause="The application is exiting.",
+    effect="Datastore cluster management services are no longer available.",
+    action="This occurs normally when the application is stopped. Wait for monit "+\
+      "to restart the application.",
+    priority=PDLog.LOG_ERR)
+EXITING_BAD_CONFIG = PDLog(
+    number=PDLog.CL_CLUSTER_MGR_ID+3,
+    desc="clearwater-cluster-manager is exiting due to bad configuration.",
+    cause="clearwater-cluster-manager was started with incorrect configuration.",
+    effect="Datastore cluster management services are no longer available.",
+    action="Verify that the configuration files in /etc/clearwater/ are correct "+\
+      "according to the documentation.",
+    priority=PDLog.LOG_ERR)
+NODE_JOINING = PDLog(
+    number=PDLog.CL_CLUSTER_MGR_ID+4,
+    desc="A node is joining a datastore cluster.",
+    cause="Node {ip} has started to join the {cluster_desc}.",
+    effect="Normal.",
+    action="None.",
+    priority=PDLog.LOG_NOTICE)
+NODE_LEAVING = PDLog(
+    number=PDLog.CL_CLUSTER_MGR_ID+5,
+    desc="A node is leaving a datastore cluster.",
+    cause="Node {ip} has started to leave the {cluster_desc}.",
+    effect="Normal.",
+    action="None.",
+    priority=PDLog.LOG_NOTICE)
 
-NOT_YET_CLUSTERED_ALARM = \
-    PDLog(number=PDLog.CL_CLUSTER_MGR_ID+6,
-          desc="This node is not yet clustered.",
-          cause="This node has not yet joined the {cluster_desc}.",
-          effect="This node will alarm until the cluster is joined.",
-          action="Wait for this node to join the cluster. If this "+\
-          "does not happen, ensure that clearwater-etcd and "+\
-          "clearwater-cluster-manager have started up, and "+\
-          "fix any other errors relating to them.",
-          priority=PDLog.LOG_ERR)
+NOT_YET_CLUSTERED_ALARM = PDLog(
+    number=PDLog.CL_CLUSTER_MGR_ID+6,
+    desc="This node is not yet clustered.",
+    cause="This node has not yet joined the {cluster_desc}.",
+    effect="This node will alarm until the cluster is joined.",
+    action="Wait for this node to join the cluster. If this does not happen, "+\
+      "ensure that clearwater-etcd and clearwater-cluster-manager have started "+\
+      "up, and fix any other errors relating to them.",
+    priority=PDLog.LOG_ERR)
 
-TOO_LONG_ALARM = \
-    PDLog(number=PDLog.CL_CLUSTER_MGR_ID+7,
-          desc="A scaling operation has taken too long".,
-          cause="A scaling operation for the {cluster_desc} has been in progress for more than 15 minutes.",
-          effect="This node will alarm until the operation finishes. No further scaling operations can begin until this one completes.",
-          action="Ensure that clearwater-etcd is running, and fix any errors relating to it. If any nodes are temporarily failed, recover them. If any nodes are permanently failed, follow the documentation to remove them from the cluster.",
-          priority=PDLog.LOG_ERR)
+TOO_LONG_ALARM = PDLog(
+    number=PDLog.CL_CLUSTER_MGR_ID+7,
+    desc="A scaling operation has taken too long".,
+    cause="A scaling operation for the {cluster_desc} has been in progress for more than 15 minutes.",
+    effect="This node will alarm until the operation finishes. "+\
+      "No further scaling operations can begin until this one completes.",
+    action="Ensure that clearwater-etcd is running, and fix any errors relating "+\
+      "to it. If any nodes are temporarily failed, recover them. If any nodes "+\
+      "are permanently failed, follow the documentation to remove them from the cluster.",
+    priority=PDLog.LOG_ERR)

--- a/src/metaswitch/clearwater/cluster_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/cluster_manager/pdlogs.py
@@ -33,41 +33,41 @@
 from metaswitch.common.pdlogs import PDLog
 
 STARTUP = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+1,
-                desc="clearwater-cluster-manager has started",
-                cause="The application is starting",
-                effect="Normal",
-                action="None",
+                desc="clearwater-cluster-manager has started.",
+                cause="The application is starting.",
+                effect="Normal.",
+                action="None.",
                 priority=PDLog.LOG_NOTICE)
 EXITING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+2,
-                desc="clearwater-cluster-manager is exiting",
-                cause="The application is exiting",
-                effect="Datastore cluster management services are no longer available",
-                action="This occurs normally when the application is stopped. Wait for monit to restart the application",
+                desc="clearwater-cluster-manager is exiting.",
+                cause="The application is exiting.",
+                effect="Datastore cluster management services are no longer available.",
+                action="This occurs normally when the application is stopped. Wait for monit to restart the application.",
                 priority=PDLog.LOG_ERR)
 EXITING_BAD_CONFIG = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+3,
-                           desc="clearwater-cluster-manager is exiting due to bad configuration",
-                           cause="clearwater-cluster-manager was started with incorrect configuration",
-                           effect="Datastore cluster management services are no longer available",
+                           desc="clearwater-cluster-manager is exiting due to bad configuration.",
+                           cause="clearwater-cluster-manager was started with incorrect configuration.",
+                           effect="Datastore cluster management services are no longer available.",
                            action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level, local_site_name and remote_site_name are set correctly.",
                            priority=PDLog.LOG_ERR)
 NODE_JOINING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+4,
-                     desc="A node is joining a datastore cluster",
-                     cause="Node {ip} has started to join the {cluster_desc}",
-                     effect="Normal",
-                     action="None",
+                     desc="A node is joining a datastore cluster.",
+                     cause="Node {ip} has started to join the {cluster_desc}.",
+                     effect="Normal.",
+                     action="None.",
                      priority=PDLog.LOG_NOTICE)
 NODE_LEAVING = PDLog(number=PDLog.CL_CLUSTER_MGR_ID+5,
-                     desc="A node is leaving a datastore cluster",
-                     cause="Node {ip} has started to leave the {cluster_desc}",
-                     effect="Normal",
-                     action="None",
+                     desc="A node is leaving a datastore cluster.",
+                     cause="Node {ip} has started to leave the {cluster_desc}.",
+                     effect="Normal.",
+                     action="None.",
                      priority=PDLog.LOG_NOTICE)
 
 NOT_YET_CLUSTERED_ALARM = \
     PDLog(number=PDLog.CL_CLUSTER_MGR_ID+6,
-          desc="This node is not yet clustered",
-          cause="This node has not yet joined the {cluster_description} cluster",
-          effect="This node will alarm until the cluster is joined",
+          desc="This node is not yet clustered.",
+          cause="This node has not yet joined the {cluster_desc}.",
+          effect="This node will alarm until the cluster is joined.",
           action="Wait for this node to join the cluster. If this "+\
           "does not happen, ensure that clearwater-etcd and "+\
           "clearwater-cluster-manager have started up, and "+\
@@ -76,8 +76,8 @@ NOT_YET_CLUSTERED_ALARM = \
 
 TOO_LONG_ALARM = \
     PDLog(number=PDLog.CL_CLUSTER_MGR_ID+7,
-          desc="A scaling operation has taken too long",
-          cause="A scaling operation for the {cluster_description} cluster has been in progress for more than 15 minutes.",
+          desc="A scaling operation has taken too long".,
+          cause="A scaling operation for the {cluster_desc} has been in progress for more than 15 minutes.",
           effect="This node will alarm until the operation finishes. No further scaling operations can begin until this one completes.",
           action="Ensure that clearwater-etcd is running, and fix any errors relating to it. If any nodes are temporarily failed, recover them. If any nodes are permanently failed, follow the documentation to remove them from the cluster.",
           priority=PDLog.LOG_ERR)

--- a/src/metaswitch/clearwater/cluster_manager/plugin_base.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_base.py
@@ -49,6 +49,9 @@ class SynchroniserPluginBase(object):
         state"""
         pass
 
+    def cluster_description(self):
+        """A brief description of the cluster managed by this plugin, for use in logs"""
+        return "[unknown] cluster"
 
     def files(self):
 

--- a/src/metaswitch/clearwater/config_manager/alarms.py
+++ b/src/metaswitch/clearwater/config_manager/alarms.py
@@ -42,6 +42,7 @@ import logging
 import imp
 import os
 from threading import Lock
+from . import pdlogs
 
 CLEAR_GLOBAL_CONFIG_NOT_SYNCHED = "6503.1"
 RAISE_GLOBAL_CONFIG_NOT_SYNCHED = "6503.3"
@@ -82,3 +83,4 @@ class ConfigAlarm(object):
             issue_alarm(CLEAR_GLOBAL_CONFIG_NOT_SYNCHED)
         else:
             issue_alarm(RAISE_GLOBAL_CONFIG_NOT_SYNCHED)
+            pdlogs.NO_SHARED_CONFIG_ALARM.log()

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -32,6 +32,9 @@
 
 import etcd
 from time import sleep
+from hashlib import md5
+
+from .pdlogs import FILE_CHANGED
 
 import urllib3
 import logging
@@ -62,8 +65,13 @@ class EtcdSynchronizer(object):
                 break
 
             if value:
+                _log.info("Got new config value from etcd - filename {}, file size {}, MD5 hash {}".format(
+                    self._plugin.file(),
+                    len(value),
+                    md5(value).hexdigest()))
                 _log.debug("Got new config value from etcd:\n{}".format(value))
                 self._plugin.on_config_changed(value, self._alarm)
+                FILE_CHANGED.log(filename=self._plugin.file())
 
     # Read the current value of the key from etcd (blocks until there's a
     # change).

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -49,7 +49,7 @@ Options:
 
 """
 
-from docopt import docopt
+from docopt import docopt, DocoptExit
 
 from metaswitch.common import logging_config, utils
 from metaswitch.clearwater.etcd_shared.plugin_loader \
@@ -74,9 +74,13 @@ LOG_LEVELS = {'0': logging.CRITICAL,
 
 
 def main(args):
-    syslog.openlog()
+    syslog.openlog("config-manager", syslog.LOG_PID)
     pdlogs.STARTUP.log()
-    arguments = docopt(__doc__, argv=args)
+    try:
+        docopt(__doc__, argv=args)
+    except DocoptExit:
+        pdlogs.EXITING_BAD_CONFIG.log()
+        raise
 
     local_ip = arguments['--local-ip']
     local_site = arguments['--local-site']

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -58,6 +58,8 @@ from metaswitch.clearwater.config_manager.etcd_synchronizer \
     import EtcdSynchronizer
 from metaswitch.clearwater.config_manager.alarms \
     import ConfigAlarm
+from metaswitch.clearwater.config_manager import pdlogs
+import syslog
 import logging
 import os
 from threading import Thread
@@ -72,6 +74,8 @@ LOG_LEVELS = {'0': logging.CRITICAL,
 
 
 def main(args):
+    syslog.openlog()
+    pdlogs.STARTUP.log()
     arguments = docopt(__doc__, argv=args)
 
     local_ip = arguments['--local-ip']
@@ -120,3 +124,5 @@ def main(args):
             thread.join(1)
 
     _log.info("Clearwater Configuration Manager shutting down")
+    pdlogs.EXITING.log()
+    syslog.closelog()

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -77,7 +77,7 @@ def main(args):
     syslog.openlog("config-manager", syslog.LOG_PID)
     pdlogs.STARTUP.log()
     try:
-        docopt(__doc__, argv=args)
+        arguments = docopt(__doc__, argv=args)
     except DocoptExit:
         pdlogs.EXITING_BAD_CONFIG.log()
         raise

--- a/src/metaswitch/clearwater/config_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/config_manager/pdlogs.py
@@ -1,9 +1,5 @@
-#!/bin/bash
-
-# @file poll_etcd.sh
-#
 # Project Clearwater - IMS in the Cloud
-# Copyright (C) 2015  Metaswitch Networks Ltd
+# Copyright (C) 2015 Metaswitch Networks Ltd
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -34,15 +30,30 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-# This script polls the local etcd process and checks whether it is healthy by
-# checking that the 4000 port is open.
-. /etc/clearwater/config
-/usr/share/clearwater/bin/poll-tcp 4000 $local_ip
-ret=$?
+from metaswitch.common.pdlog import PDLog
 
-if [ $ret != 0 ]
-then
-  /usr/share/clearwater/bin/ent_log.py CL_ETCD_POLL_FAILED
-fi
+STARTUP = PDLog(desc="clearwater-cluster-manager has started",
+                cause="The application is starting",
+                effect="Normal",
+                action="None",
+                priority=PDLog.LOG_NOTICE)
+EXITING = PDLog(desc="clearwater-cluster-manager is exiting",
+                cause="The application is exiting",
+                effect="???",
+                action="???",
+                priority=PDLog.LOG_NOTICE)
+FILE_CHANGED = PDLog(desc="A shared configuration file has been changed",
+                     cause="The shared state of {filename} has changed",
+                     effect="Normal",
+                     action="None",
+                     priority=PDLog.LOG_NOTICE)
 
-exit $ret
+NO_SHARED_CONFIG_ALARM = \
+    PDLog(desc="This node has no shared config",
+          cause="This node has not yet retrieved its shared config",
+          effect="This node will alarm until it retrieves shared config",
+          action="Wait for this node to retrieve /etc/clearwater/shared_config. If this "+\
+          "does not happen, ensure that clearwater-etcd and "+\
+          "clearwater-config-manager have started up, and "+\
+          "fix any other errors relating to them.",
+          priority=PDLog.LOG_ERR)

--- a/src/metaswitch/clearwater/config_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/config_manager/pdlogs.py
@@ -32,38 +32,43 @@
 
 from metaswitch.common.pdlogs import PDLog
 
-STARTUP = PDLog(number=PDLog.CL_CONFIG_MGR_ID+1,
-                desc="clearwater-config-manager has started.",
-                cause="The application is starting.",
-                effect="Normal.",
-                action="None.",
-                priority=PDLog.LOG_NOTICE)
-EXITING = PDLog(number=PDLog.CL_CONFIG_MGR_ID+2,
-                desc="clearwater-config-manager is exiting.",
-                cause="The application is exiting.",
-                effect="Configuration management services are no longer available.",
-                action="This occurs normally when the application is stopped. Wait for monit to restart the application.",
-                priority=PDLog.LOG_ERR)
-EXITING_BAD_CONFIG = PDLog(number=PDLog.CL_CONFIG_MGR_ID+3,
-                           desc="clearwater-config-manager is exiting due to bad configuration.",
-                           cause="clearwater-config-manager was started with incorrect configuration.",
-                           effect="Configuration management services are no longer available.",
-                           action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level and local_site_name are set correctly.",
-                           priority=PDLog.LOG_ERR)
-FILE_CHANGED = PDLog(number=PDLog.CL_CONFIG_MGR_ID+4,
-                     desc="A shared configuration file has been changed.",
-                     cause="The shared state of {filename} has changed.",
-                     effect="Normal.",
-                     action="None.",
-                     priority=PDLog.LOG_NOTICE)
+STARTUP = PDLog(
+    number=PDLog.CL_CONFIG_MGR_ID+1,
+    desc="clearwater-config-manager has started.",
+    cause="The application is starting.",
+    effect="Normal.",
+    action="None.",
+    priority=PDLog.LOG_NOTICE)
+EXITING = PDLog(
+    number=PDLog.CL_CONFIG_MGR_ID+2,
+    desc="clearwater-config-manager is exiting.",
+    cause="The application is exiting.",
+    effect="Configuration management services are no longer available.",
+    action="This occurs normally when the application is stopped. Wait for monit "+\
+      "to restart the application.",
+    priority=PDLog.LOG_ERR)
+EXITING_BAD_CONFIG = PDLog(
+    number=PDLog.CL_CONFIG_MGR_ID+3,
+    desc="clearwater-config-manager is exiting due to bad configuration.",
+    cause="clearwater-config-manager was started with incorrect configuration.",
+    effect="Configuration management services are no longer available.",
+    action="Verify that the configuration files in /etc/clearwater/ are correct "+\
+      "according to the documentation.",
+    priority=PDLog.LOG_ERR)
+FILE_CHANGED = PDLog(
+    number=PDLog.CL_CONFIG_MGR_ID+4,
+    desc="A shared configuration file has been changed.",
+    cause="The shared state of {filename} has changed.",
+    effect="Normal.",
+    action="None.",
+    priority=PDLog.LOG_NOTICE)
 
-NO_SHARED_CONFIG_ALARM = \
-    PDLog(number=PDLog.CL_CONFIG_MGR_ID+5,
-          desc="This node has no shared config.",
-          cause="This node has not yet retrieved its shared config.",
-          effect="This node will alarm until it retrieves shared config.",
-          action="Wait for this node to retrieve /etc/clearwater/shared_config. If this "+\
-          "does not happen, ensure that clearwater-etcd and "+\
-          "clearwater-config-manager have started up, and "+\
-          "fix any other errors relating to them.",
-          priority=PDLog.LOG_ERR)
+NO_SHARED_CONFIG_ALARM = PDLog(
+    number=PDLog.CL_CONFIG_MGR_ID+5,
+    desc="This node has no shared config.",
+    cause="This node has not yet retrieved its shared config.",
+    effect="This node will alarm until it retrieves shared config.",
+    action="Wait for this node to retrieve /etc/clearwater/shared_config. If this "+\
+    "does not happen, ensure that clearwater-etcd and clearwater-config-manager "+\
+    "have started up, and fix any other errors relating to them.",
+    priority=PDLog.LOG_ERR)

--- a/src/metaswitch/clearwater/config_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/config_manager/pdlogs.py
@@ -32,29 +32,34 @@
 
 from metaswitch.common.pdlogs import PDLog
 
-STARTUP = PDLog(desc="clearwater-config-manager has started",
+STARTUP = PDLog(number=PDLog.CL_CONFIG_MGR_ID+1,
+                desc="clearwater-config-manager has started",
                 cause="The application is starting",
                 effect="Normal",
                 action="None",
                 priority=PDLog.LOG_NOTICE)
-EXITING = PDLog(desc="clearwater-config-manager is exiting",
+EXITING = PDLog(number=PDLog.CL_CONFIG_MGR_ID+2,
+                desc="clearwater-config-manager is exiting",
                 cause="The application is exiting",
                 effect="Configuration management services are no longer available",
                 action="This occurs normally when the application is stopped. Wait for monit to restart the application",
                 priority=PDLog.LOG_ERR)
-EXITING_BAD_CONFIG = PDLog(desc="clearwater-config-manager is exiting due to bad configuration",
+EXITING_BAD_CONFIG = PDLog(number=PDLog.CL_CONFIG_MGR_ID+3,
+                           desc="clearwater-config-manager is exiting due to bad configuration",
                            cause="clearwater-config-manager was started with incorrect configuration",
                            effect="Configuration management services are no longer available",
                            action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level and local_site_name are set correctly.",
                            priority=PDLog.LOG_ERR)
-FILE_CHANGED = PDLog(desc="A shared configuration file has been changed",
+FILE_CHANGED = PDLog(number=PDLog.CL_CONFIG_MGR_ID+4,
+                     desc="A shared configuration file has been changed",
                      cause="The shared state of {filename} has changed",
                      effect="Normal",
                      action="None",
                      priority=PDLog.LOG_NOTICE)
 
 NO_SHARED_CONFIG_ALARM = \
-    PDLog(desc="This node has no shared config",
+    PDLog(number=PDLog.CL_CONFIG_MGR_ID+5,
+          desc="This node has no shared config",
           cause="This node has not yet retrieved its shared config",
           effect="This node will alarm until it retrieves shared config",
           action="Wait for this node to retrieve /etc/clearwater/shared_config. If this "+\

--- a/src/metaswitch/clearwater/config_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/config_manager/pdlogs.py
@@ -32,16 +32,21 @@
 
 from metaswitch.common.pdlogs import PDLog
 
-STARTUP = PDLog(desc="clearwater-cluster-manager has started",
+STARTUP = PDLog(desc="clearwater-config-manager has started",
                 cause="The application is starting",
                 effect="Normal",
                 action="None",
                 priority=PDLog.LOG_NOTICE)
-EXITING = PDLog(desc="clearwater-cluster-manager is exiting",
+EXITING = PDLog(desc="clearwater-config-manager is exiting",
                 cause="The application is exiting",
-                effect="???",
-                action="???",
-                priority=PDLog.LOG_NOTICE)
+                effect="Configuration management services are no longer available",
+                action="This occurs normally when the application is stopped. Wait for monit to restart the application",
+                priority=PDLog.LOG_ERR)
+EXITING_BAD_CONFIG = PDLog(desc="clearwater-config-manager is exiting due to bad configuration",
+                           cause="clearwater-config-manager was started with incorrect configuration",
+                           effect="Configuration management services are no longer available",
+                           action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level and local_site_name are set correctly.",
+                           priority=PDLog.LOG_ERR)
 FILE_CHANGED = PDLog(desc="A shared configuration file has been changed",
                      cause="The shared state of {filename} has changed",
                      effect="Normal",

--- a/src/metaswitch/clearwater/config_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/config_manager/pdlogs.py
@@ -30,7 +30,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-from metaswitch.common.pdlog import PDLog
+from metaswitch.common.pdlogs import PDLog
 
 STARTUP = PDLog(desc="clearwater-cluster-manager has started",
                 cause="The application is starting",

--- a/src/metaswitch/clearwater/config_manager/pdlogs.py
+++ b/src/metaswitch/clearwater/config_manager/pdlogs.py
@@ -33,35 +33,35 @@
 from metaswitch.common.pdlogs import PDLog
 
 STARTUP = PDLog(number=PDLog.CL_CONFIG_MGR_ID+1,
-                desc="clearwater-config-manager has started",
-                cause="The application is starting",
-                effect="Normal",
-                action="None",
+                desc="clearwater-config-manager has started.",
+                cause="The application is starting.",
+                effect="Normal.",
+                action="None.",
                 priority=PDLog.LOG_NOTICE)
 EXITING = PDLog(number=PDLog.CL_CONFIG_MGR_ID+2,
-                desc="clearwater-config-manager is exiting",
-                cause="The application is exiting",
-                effect="Configuration management services are no longer available",
-                action="This occurs normally when the application is stopped. Wait for monit to restart the application",
+                desc="clearwater-config-manager is exiting.",
+                cause="The application is exiting.",
+                effect="Configuration management services are no longer available.",
+                action="This occurs normally when the application is stopped. Wait for monit to restart the application.",
                 priority=PDLog.LOG_ERR)
 EXITING_BAD_CONFIG = PDLog(number=PDLog.CL_CONFIG_MGR_ID+3,
-                           desc="clearwater-config-manager is exiting due to bad configuration",
-                           cause="clearwater-config-manager was started with incorrect configuration",
-                           effect="Configuration management services are no longer available",
+                           desc="clearwater-config-manager is exiting due to bad configuration.",
+                           cause="clearwater-config-manager was started with incorrect configuration.",
+                           effect="Configuration management services are no longer available.",
                            action="Verify that the configuration files in /etc/clearwater/ are correct according to the documentation. In particular, ensure that local_ip, management_local_ip, log_level and local_site_name are set correctly.",
                            priority=PDLog.LOG_ERR)
 FILE_CHANGED = PDLog(number=PDLog.CL_CONFIG_MGR_ID+4,
-                     desc="A shared configuration file has been changed",
-                     cause="The shared state of {filename} has changed",
-                     effect="Normal",
-                     action="None",
+                     desc="A shared configuration file has been changed.",
+                     cause="The shared state of {filename} has changed.",
+                     effect="Normal.",
+                     action="None.",
                      priority=PDLog.LOG_NOTICE)
 
 NO_SHARED_CONFIG_ALARM = \
     PDLog(number=PDLog.CL_CONFIG_MGR_ID+5,
-          desc="This node has no shared config",
-          cause="This node has not yet retrieved its shared config",
-          effect="This node will alarm until it retrieves shared config",
+          desc="This node has no shared config.",
+          cause="This node has not yet retrieved its shared config.",
+          effect="This node will alarm until it retrieves shared config.",
           action="Wait for this node to retrieve /etc/clearwater/shared_config. If this "+\
           "does not happen, ensure that clearwater-etcd and "+\
           "clearwater-config-manager have started up, and "+\


### PR DESCRIPTION
Note that:
  * the NOT_YET_CLUSTERED_ALARM log will be created by plugins
  * I've added a cluster_description method to plugins (returning something like 'remote memcached cluster') and will add that to all existing plugins