### PR TITLE
[Reviewer: Andy] Traffic separation fixes

### DIFF
--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -93,7 +93,13 @@ do_start()
   log_directory=/var/log/clearwater-cluster-manager
   [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 
-  DAEMON_ARGS="--local-ip=$local_ip
+  if [ -z $management_local_ip ]
+  then
+    management_local_ip=$local_ip
+  fi
+
+  DAEMON_ARGS="--mgmt-local-ip=$management_local_ip
+               --sig-local-ip=$local_ip
                --local-site=$local_site_name
                --remote-site=$remote_site_name
                --signaling-namespace=$signaling_namespace

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -42,7 +42,7 @@ Usage:
 Options:
   -h --help                   Show this screen.
   --mgmt-local-ip=IP          Management IP address
-  --sig-local-ip=IP           Signalling IP address
+  --sig-local-ip=IP           Signaling IP address
   --local-site=NAME           Name of local site
   --remote-site=NAME          Name of remote site
   --signaling-namespace=NAME  Name of the signaling namespace

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -68,9 +68,11 @@ import signal
 
 _log = logging.getLogger("cluster_manager.main")
 
-LOG_LEVELS = {'0': logging.CRITICAL,
-              '1': logging.ERROR,
-              '2': logging.WARNING,
+LOG_LEVELS = {'0': logging.ERROR,
+              '1': logging.WARNING,
+              # INFO-level logging is really useful, and not very spammy because
+              # we're not on the call path, so produce INFO logs even at level 2
+              '2': logging.INFO,
               '3': logging.INFO,
               '4': logging.DEBUG}
 

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -35,13 +35,14 @@
 """Clearwater Cluster Manager
 
 Usage:
-  main.py --local-ip=IP --local-site=NAME --remote-site=NAME
+  main.py --mgmt-local-ip=IP --sig-local-ip=IP --local-site=NAME --remote-site=NAME
           [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
           [--log-directory=DIR] [--pidfile=FILE]
 
 Options:
   -h --help                   Show this screen.
-  --local-ip=IP               IP address
+  --mgmt-local-ip=IP          Management IP address
+  --sig-local-ip=IP           Signalling IP address
   --local-site=NAME           Name of local site
   --remote-site=NAME          Name of remote site
   --signaling-namespace=NAME  Name of the signaling namespace
@@ -99,7 +100,8 @@ def install_sigterm_handler(plugins):
 def main(args):
     arguments = docopt(__doc__, argv=args)
 
-    listen_ip = arguments['--local-ip']
+    mgmt_ip = arguments['--mgmt-local-ip']
+    sig_ip = arguments['--sig-local-ip']
     local_site_name = arguments['--local-site']
     remote_site_name = arguments['--remote-site']
     signaling_namespace = arguments.get('--signaling-namespace')
@@ -128,7 +130,8 @@ def main(args):
 
     plugins_dir = "/usr/share/clearwater/clearwater-cluster-manager/plugins/"
     plugins = load_plugins_in_dir(plugins_dir,
-                                  PluginParams(ip=listen_ip,
+                                  PluginParams(ip=sig_ip,
+                                               mgmt_ip=mgmt_ip,
                                                local_site=local_site_name,
                                                remote_site=remote_site_name,
                                                signaling_namespace=signaling_namespace))
@@ -151,7 +154,7 @@ def main(args):
     synchronizers = []
     threads = []
     for plugin in plugins_to_use:
-        syncer = EtcdSynchronizer(plugin, listen_ip)
+        syncer = EtcdSynchronizer(plugin, sig_ip, etcd_ip=mgmt_ip)
         syncer.start_thread()
 
         synchronizers.append(syncer)

--- a/src/metaswitch/clearwater/cluster_manager/plugin_base.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_base.py
@@ -36,7 +36,7 @@ import collections
 
 PluginParams = collections.namedtuple(
                  'PluginParams',
-                 ['ip', 'local_site', 'remote_site', 'signaling_namespace'])
+                 ['ip', 'mgmt_ip', 'local_site', 'remote_site', 'signaling_namespace'])
 
 
 class SynchroniserPluginBase(object):

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -64,12 +64,13 @@ from threading import Thread
 
 _log = logging.getLogger("config_manager.main")
 
-LOG_LEVELS = {'0': logging.CRITICAL,
-              '1': logging.ERROR,
-              '2': logging.WARNING,
+LOG_LEVELS = {'0': logging.ERROR,
+              '1': logging.WARNING,
+              # INFO-level logging is really useful, and not very spammy because
+              # we're not on the call path, so produce INFO logs even at level 2
+              '2': logging.INFO,
               '3': logging.INFO,
               '4': logging.DEBUG}
-
 
 def main(args):
     arguments = docopt(__doc__, argv=args)


### PR DESCRIPTION
Key changes are:
* clearwater-cluster-manager needs to know both the signalling and management IPs, so pass both in
* clearwater-cluster-manager can't connect to Cassandra directly due to network namespaces, so it needs to use /usr/share/clearwater/bin/poll-tcp for that
* (slightly unrelated) clearwater-cluster-manager was specced as logging at INFO level by default, as it's not on the call path and these logs are useful. I previously did that by having `log_level=3` in the init.d script, but explicitly setting `log_level=2` breaks that, so I've changed it to translate 2 to INFO level.

These are fixes for #110 .