### PR TITLE
[Reviewer: Alex] 14.04 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ENV_DIR := $(shell pwd)/_env
 ENV_PYTHON := ${ENV_DIR}/bin/python
+TEST_ENV_DIR := $(shell pwd)/_test_env
+TEST_ENV_PYTHON := ${TEST_ENV_DIR}/bin/python
 PYTHON_BIN := $(shell which python)
 
 DEB_COMPONENT := clearwater-etcd
@@ -13,8 +15,8 @@ X86_64_ONLY=0
 .DEFAULT_GOAL = deb
 
 .PHONY: test
-test: cluster_mgr_setup.py env
-	$(ENV_DIR)/bin/python cluster_mgr_setup.py test -v
+test: cluster_mgr_setup.py ${TEST_ENV_PYTHON}
+	PYTHONPATH=src:common ${TEST_ENV_PYTHON} cluster_mgr_setup.py test -v
 
 ${ENV_DIR}/bin/flake8: env
 	${ENV_DIR}/bin/pip install flake8
@@ -41,6 +43,12 @@ coverage: ${ENV_DIR}/bin/coverage cluster_mgr_setup.py
 
 .PHONY: env
 env: cluster_mgr_setup.py config_mgr_setup.py shared_setup.py $(ENV_DIR)/bin/python build-eggs install-eggs
+
+$(TEST_ENV_PYTHON):
+	# Set up the virtual environment
+	virtualenv --setuptools --python=$(PYTHON_BIN) $(TEST_ENV_DIR)
+	$(TEST_ENV_DIR)/bin/easy_install "setuptools>0.7"
+	$(TEST_ENV_DIR)/bin/easy_install distribute
 
 $(ENV_DIR)/bin/python:
 	# Set up the virtual environment
@@ -101,4 +109,5 @@ envclean:
 	rm -rf bin cluster_mgr_eggs config_mgr_eggs develop-eggs parts .installed.cfg bootstrap.py .downloads .buildout_downloads *.egg .eggs *.egg-info
 	rm -rf distribute-*.tar.gz
 	rm -rf $(ENV_DIR)
+	rm -rf $(TEST_ENV_DIR)
 

--- a/src/metaswitch/clearwater/cluster_manager/test/test_node_failure.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_node_failure.py
@@ -82,5 +82,5 @@ class TestNodeFailure(BaseClusterTest):
         self.assertEqual("normal", end.get("10.0.0.1"))
         self.assertEqual("normal", end.get("10.0.0.3"))
         self.assertEqual(None, end.get("10.0.0.2"))
-        for s in [sync1, sync3]:
+        for s in [sync1, sync3, error_syncer]:
             s.terminate()

--- a/src/metaswitch/clearwater/cluster_manager/test/test_scale_down.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_scale_down.py
@@ -58,6 +58,7 @@ class TestScaleDown(BaseClusterTest):
         # Make the second node leave
         sync2.leave_cluster()
         sync2.thread.join(20)
+        sync2.terminate()
         self.wait_for_all_normal(mock_client, required_number=1)
 
         # Check that it's left and the cluster is stable


### PR DESCRIPTION
I hit two issues when setting up clearwater-etcd on 14.04:

* The UTs didn't run. This was because we install the .egg files into the development virtualenv - on 12.04 this is OK, but in 14.04 this seems to mean that you can't see the 'test' directory (which is only in the local system, not the egg). Fix is to not install the .egg files and just set PYTHONPATH appropriately.
* Once the UTs ran, they didn't terminate. This was because I hadn't cleaned up a couple of EtcdSynchronizers, so their background thread was still running.