### PR TITLE
[Reviewer: Andy] Attempt to join all threads regularly

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -174,9 +174,10 @@ def main(args):
     install_sigquit_handler(synchronizers)
     install_sigterm_handler(synchronizers)
 
-    for thread in threads:
-        while thread.isAlive():
-            thread.join(1)
+    while any([thread.isAlive() for thread in threads]):
+        for thread in threads:
+            if thread.isAlive():
+                thread.join(1)
 
     _log.info("No plugin threads running, waiting for a SIGTERM or SIGQUIT")
     while not should_quit:

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -124,9 +124,10 @@ def main(args):
         threads.append(thread)
         _log.info("Loaded plugin %s" % plugin)
 
-    for thread in threads:
-        while thread.isAlive():
-            thread.join(1)
+    while any([thread.isAlive() for thread in threads]):
+        for thread in threads:
+            if thread.isAlive():
+                thread.join(1)
 
     _log.info("Clearwater Configuration Manager shutting down")
     pdlogs.EXITING.log()


### PR DESCRIPTION
Previously, we attempted to join threads one at a time - so if thread 2 threw an exception, we wouldn't catch that and restart until thread 1 joined (potentially a very long time). This restructures things so that if any thread throws an exception, we'll spot it as soon as we can.

Not tested at all.