### PR TITLE
[Reviewer: Andy] Cope with etcd index failures

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -174,9 +174,10 @@ def main(args):
     install_sigquit_handler(synchronizers)
     install_sigterm_handler(synchronizers)
 
-    for thread in threads:
-        while thread.isAlive():
-            thread.join(1)
+    while any([thread.isAlive() for thread in threads]):
+        for thread in threads:
+            if thread.isAlive():
+                thread.join(1)
 
     _log.info("No plugin threads running, waiting for a SIGTERM or SIGQUIT")
     while not should_quit:

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -98,7 +98,6 @@ class EtcdSynchronizer(object):
             if result is None or result.modifiedIndex == self._index:
                 while not self._terminate_flag:
                     _log.info("Watching for changes")
-                    # Calculate the args for the wait
                     waitIndex = None if (self.index is None or result is None) else result.modifiedIndex + 1
                     result = self.waitHelper(timeout=0, waitIndex=waitIndex)
 

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -165,11 +165,4 @@ class EtcdSynchronizer(object):
                 pass
             else:
                 raise
-        except ValueError:
-            # The index isn't valid to watch on, probably because
-            # there has been a snapshot between the get and the
-            # watch. Just start the read again.
-            _log.info("etcd index {} is invalid, retrying".format(
-                result.modifiedIndex+1))
-            self.read_from_etcd()
         return result

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -124,9 +124,10 @@ def main(args):
         threads.append(thread)
         _log.info("Loaded plugin %s" % plugin)
 
-    for thread in threads:
-        while thread.isAlive():
-            thread.join(1)
+    while any([thread.isAlive() for thread in threads]):
+        for thread in threads:
+            if thread.isAlive():
+                thread.join(1)
 
     _log.info("Clearwater Configuration Manager shutting down")
     pdlogs.EXITING.log()


### PR DESCRIPTION
See the comment at https://github.com/Metaswitch/clearwater-etcd/compare/etcd_invalid_index?expand=1#diff-420c3a9c99bb96c4ca6213ef1e154c0cR148 for the basis of the change.

I'm going to test by hacking init.d to set the `--snapshot-count 5` option to etcd to force ludicrously frequent snapshots, spin up a deployment, check it's usable, and check that I've seen my new log (and that we've subsequently recovered from this state).

If that test doesn't hit this error condition, I can't see another good way to test it, so might just have to merge as-is.