### PR TITLE
Reviewer Alex - Remove home_domain reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Configuration for the `clearwater-etcd` cluster is done through the standard
 
  * `etcd_cluster` - See below
  * `local_ip` - The local IP address
- * `home_domain` - Used as a unique identity
 
 ## Creating a Cluster
 


### PR DESCRIPTION
https://github.com/Metaswitch/clearwater-etcd/commit/0df3c13b26ae356bc0962b1194dd6cd51ad95ba9 removed the need to supply `home_domain` in `local_config`.  This change just updates the README to match.