### PR TITLE
[Reviewer: Ellie] Fix issues with incomplete code coverage and scale-down leaving nodes…

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/constants.py
+++ b/src/metaswitch/clearwater/cluster_manager/constants.py
@@ -60,3 +60,5 @@ LEAVING_ACKNOWLEDGED_CHANGE = "leaving, acknowledged change"
 LEAVING_CONFIG_CHANGED = "leaving, config changed"
 FINISHED = "finished"
 ERROR = "error"
+
+DELETE_ME = "DELETE_ME"

--- a/src/metaswitch/clearwater/cluster_manager/constants.py
+++ b/src/metaswitch/clearwater/cluster_manager/constants.py
@@ -61,4 +61,6 @@ LEAVING_CONFIG_CHANGED = "leaving, config changed"
 FINISHED = "finished"
 ERROR = "error"
 
+# Pseudo-state - this state never gets written into etcd, we just delete the
+# node's entry from etcd when we hit this state
 DELETE_ME = "DELETE_ME"

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -142,7 +142,9 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
         # Update the cluster view based on new state information. If new_state
         # is a string then it refers to the new state of the local node.
         # Otherwise, it is an overall picture of the new cluster.
-        if isinstance(new_state, str):
+        if new_state == constants.DELETE_ME:
+            del cluster_view[self._ip]
+        elif isinstance(new_state, str):
             cluster_view[self._ip] = new_state
         elif isinstance(new_state, dict):
             cluster_view = new_state
@@ -161,7 +163,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
             # flag.
             self._leaving_flag = False
         except ValueError:
-            _log.debug("Contention on etcd write")
+            _log.debug("Contention on etcd write - new_state is {}".format(new_state))
             # Our etcd write failed because someone got there before us.
 
             if isinstance(new_state, str):
@@ -174,11 +176,12 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 # or the overall deployment state has changed (in which case we
                 # may want to change our state to something else, so check for
                 # that.
-                if ((new_state == constants.ERROR) or
-                    (updated_cluster_info.local_state(self._ip) ==
+                if (new_state in [constants.ERROR, constants.DELETE_ME] or
+                    ((updated_cluster_info.local_state(self._ip) ==
                      cluster_info.local_state(self._ip)) and
                     (updated_cluster_info.cluster_state ==
-                     cluster_info.cluster_state)):
+                     cluster_info.cluster_state))):
+                    _log.debug("Retrying contended write with updated value")
                     self.write_to_etcd(updated_cluster_info,
                                        new_state,
                                        with_index=idx)

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -176,7 +176,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 # or the overall deployment state has changed (in which case we
                 # may want to change our state to something else, so check for
                 # that.
-                if (new_state in [constants.ERROR, constants.DELETE_ME] or
+                if ((new_state in [constants.ERROR, constants.DELETE_ME]) or
                     ((updated_cluster_info.local_state(self._ip) ==
                      cluster_info.local_state(self._ip)) and
                     (updated_cluster_info.cluster_state ==

--- a/src/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
+++ b/src/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
@@ -95,9 +95,6 @@ class SyncFSM(object):
         return {k: (constants.LEAVING if v == constants.WAITING_TO_LEAVE else v)
                 for k, v in cluster_view.iteritems()}
 
-    def _delete_myself(self, cluster_view):
-        return {k: v for k, v in cluster_view.iteritems() if k != self._id}
-
     def _log_joining_nodes(self, cluster_view):
         for node, state in cluster_view.iteritems():
             if state in [constants.JOINING, constants.JOINING_ACKNOWLEDGED_CHANGE]:
@@ -145,10 +142,12 @@ class SyncFSM(object):
         # in any cluster state, so don't fit neatly into the main function body.
 
         if not self._plugin.should_be_in_cluster():
-            # This plugin is just monitoring a remote cluster
+            # This plugin is just monitoring a remote cluster.
             if cluster_state in [constants.JOINING_CONFIG_CHANGING,
                                  constants.LEAVING_CONFIG_CHANGING]:
-                safe_plugin(self._plugin.on_cluster_changing,
+                # This branch is not guaranteed to be hit due to
+                # https://github.com/Metaswitch/clearwater-etcd/issues/158.
+                safe_plugin(self._plugin.on_cluster_changing, # pragma: no cover
                             cluster_view)
             elif cluster_state == constants.STABLE:
                 safe_plugin(self._plugin.on_stable_cluster,
@@ -363,7 +362,9 @@ class SyncFSM(object):
 
         elif (cluster_state == constants.FINISHED_LEAVING and
                 local_state == constants.NORMAL):
-            return None
+            # Not guaranteed to hit this state, as the 'finished' nodes could
+            # all leave before the non-leaving nodes spot that state transition
+            return None # pragma: no cover
         elif (cluster_state == constants.FINISHED_LEAVING and
                 local_state == constants.FINISHED):
             # This node is finished, so this state machine (and this thread)
@@ -371,7 +372,7 @@ class SyncFSM(object):
             self._running = False
             return safe_plugin(self._plugin.on_leaving_cluster,
                                cluster_view,
-                               new_state=self._delete_myself(cluster_view))
+                               new_state=constants.DELETE_ME)
 
         # Any valid state should have caused me to return by now
         _log.error("Invalid state in state machine for {} - local state {}, "


### PR DESCRIPTION
… permanaently in finished state

This fixes various intermittent code coverage gaps
- we didn't have a UT where two nodes left the cluster at the same time, so didn't hit some local state/cluster state pairs
- there are some states we're not guaranteed to hit, either because the cluster manager doesn't need to block at those points, or due to #158 

In adding a UT where two nodes left the cluster at the same time, I also hit and fixed #159.

I've run `make coverage` 20+ times in a row without falling below 100%, so I think this has flushed out all but the most intermittent of issues.