### PR TITLE
[No reviewer] Revert eternal watch

### DIFF
--- a/shared_setup.py
+++ b/shared_setup.py
@@ -46,6 +46,6 @@ setup(
     package_data={
         '': ['*.eml'],
         },
-    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "futures"],
+    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml"],
     tests_require=["Mock"],
     )

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -96,7 +96,6 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
 
         _log.info("Quitting FSM")
         self._fsm.quit()
-        self.executor.shutdown(wait=False)
 
     # This node has been asked to leave the cluster. Check if the cluster is in
     # a stable state, in which case we can leave. Otherwise, set a flag and

--- a/src/metaswitch/clearwater/cluster_manager/test/test_base.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_base.py
@@ -53,6 +53,7 @@ class BaseClusterTest(unittest.TestCase):
         SyncFSM.DELAY = 0.1
         CommonEtcdSynchronizer.PAUSE_BEFORE_RETRY_ON_EXCEPTION = 0
         CommonEtcdSynchronizer.PAUSE_BEFORE_RETRY_ON_MISSING_KEY = 0
+        CommonEtcdSynchronizer.TIMEOUT_ON_WATCH = 0
         MockEtcdClient.clear()
         alarms_patch.start()
         self.syncs = []

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -65,7 +65,5 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 self._plugin.on_config_changed(value, self._alarm)
                 FILE_CHANGED.log(filename=self._plugin.file())
 
-        self.executor.shutdown(wait=False)
-
     def key(self):
         return "/" + self._key + "/" + self._site + "/configuration/" + self._plugin.key()


### PR DESCRIPTION
Having an eternal watch means that the python-etcd client will miss updates (it sticks watching on an old index). I'm reverting the futures fix (which means we'll still hit #166) for now