### PR TITLE
Reviewer AMC: Read stats rather than write values in poll etcd

### DIFF
--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
@@ -48,7 +48,7 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo etcd poll failed to $key_path$key >&2
+  echo etcd poll failed to $stat_path    >&2
   cat /tmp/poll-etcd.sh.stderr.$$        >&2
   cat /tmp/poll-etcd.sh.stdout.$$        >&2
 fi

--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
@@ -35,17 +35,15 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 # This script polls the local etcd process. It checks whether etcd is healthy by
-# trying to write a key/value pair to etcd. We need to do this rather than
+# trying to read local etcd stats. We need to do this rather than
 # just use poll-tcp on port 4000 as etcd can listen to its port but still
 # not be functioning correctly
 . /etc/clearwater/config
 
-key_path="http://${management_local_ip:-$local_ip}:4000/v2/keys"
-key="/clearwater/${management_local_ip:-$local_ip}/liveness-check"
-value="True"
-output="\"key\":\"$key\",\"value\":\"$value\""
+stat_path="http://${management_local_ip:-$local_ip}:4000/v2/stats/self"
+output="\"name\":\"${management_local_ip:-$local_ip}\""
 
-curl -L $key_path$key -XPUT -d value=$value 2> /tmp/poll-etcd.sh.stderr.$$ | tee /tmp/poll-etcd.sh.stdout.$$ | grep -q $output
+curl -L $stat_path 2> /tmp/poll-etcd.sh.stderr.$$ | tee /tmp/poll-etcd.sh.stdout.$$ | grep -q $output
 rc=$?
 
 # Check the return code and log if appropriate.


### PR DESCRIPTION
Change behaviour of the poll_etcd script to read stats values from etcd, rather than write a test "liveness-check" key. The reason why the write check needs to be reworked is that the write will fail if the cluster is non-quorate, so monit will repeatedly kill etcd on each healthy node if the cluster is in this state, making it harder to diagnose the fault with the cluster and potentially impacting the ability of the cluster to recover from the condition.

The stats read succeeds if the cluster is non-quorate, and is still a check that the etcd process is responsive.

Tested against quorate and non-quorate clusters.  The script has also been tested against a non responsive etcd cluster (by temporarily changing the script to point at port 2380 rather than 4000 so that the stat request won't work properly).  Monit restarted etcd as required here.

One question for the reviewer: the consequence of this change is that "liveness-check" won't be created in the etcd value store.  Are there any other mechanisms in Clearwater that expect it to be there?