### PR TITLE
[Reviewer: Alex] Fix waiting to leave hang

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -77,7 +77,8 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 # necessary, set this node to WAITING_TO_LEAVE. Otherwise, kick
                 # the FSM.
                 if (self._leaving_flag and
-                        cluster_info.can_leave(self.force_leave)):
+                    cluster_info.local_state(self._ip) != constants.WAITING_TO_LEAVE and
+                    cluster_info.can_leave(self.force_leave)):
                     _log.info("Cluster is in a stable state, so leaving the cluster now")
                     new_state = constants.WAITING_TO_LEAVE
                 else:
@@ -162,7 +163,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
             # We may have just successfully set the local node to
             # WAITING_TO_LEAVE, in which case we no longer need the leaving
             # flag.
-            if new_state == constants.WAITING_TO_LEAVE:
+            if isinstance(new_state, str) and new_state == constants.WAITING_TO_LEAVE:
                 self._leaving_flag = False
         except (EtcdAlreadyExist, ValueError):
             _log.debug("Contention on etcd write - new_state is {}".format(new_state))

--- a/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
@@ -48,7 +48,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
     def __init__(self, plugin, ip, etcd_ip=None, force_leave=False):
         super(EtcdSynchronizer, self).__init__(plugin, ip, etcd_ip)
         self._fsm = SyncFSM(self._plugin, self._ip)
-        self._leaving_flag = False
+        self._leaving_requested = False
         self.force_leave = force_leave
 
     def key(self):
@@ -73,10 +73,13 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 cluster_info = ClusterInfo(etcd_value)
 
                 # This node can only leave the cluster if the cluster is in a
-                # stable state. Check the leaving flag and the cluster state. If
-                # necessary, set this node to WAITING_TO_LEAVE. Otherwise, kick
+                # stable state. Also check that we've both requested to leave
+                # and we're not already leaving (there's a race condition where
+                # the requested flag can only be cleared after updating etcd, but
+                # updating etcd triggers this function to be called).
+                # If necessary, set this node to WAITING_TO_LEAVE. Otherwise, kick
                 # the FSM.
-                if (self._leaving_flag and
+                if (self._leaving_requested and
                     cluster_info.local_state(self._ip) != constants.WAITING_TO_LEAVE and
                     cluster_info.can_leave(self.force_leave)):
                     _log.info("Cluster is in a stable state, so leaving the cluster now")
@@ -113,7 +116,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
         etcd_result, idx = self.read_from_etcd(wait=False)
         cluster_info = ClusterInfo(etcd_result)
 
-        self._leaving_flag = True
+        self._leaving_requested = True
         if cluster_info.can_leave(self.force_leave):
             _log.info("Cluster is in a stable state, so leaving the cluster immediately")
             self.write_to_etcd(cluster_info, constants.WAITING_TO_LEAVE)
@@ -163,8 +166,8 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
             # We may have just successfully set the local node to
             # WAITING_TO_LEAVE, in which case we no longer need the leaving
             # flag.
-            if isinstance(new_state, str) and new_state == constants.WAITING_TO_LEAVE:
-                self._leaving_flag = False
+            if new_state == constants.WAITING_TO_LEAVE:
+                self._leaving_requested = False
         except (EtcdAlreadyExist, ValueError):
             _log.debug("Contention on etcd write - new_state is {}".format(new_state))
             # Our etcd write failed because someone got there before us.


### PR DESCRIPTION
Alex, can you review this fix to stop scale downs from getting stuck in the 'waiting to leave' state. The problem was that there was a race condition where:
* leave_cluster sets the leaving_flag to true, then attempts to write the 'waiting to leave' state into etcd. 
* after it has successfully written to etcd it sets the leaving flag to false. 
* writing to etcd triggers the main etcd_synchronizer starts processing again though, so at the same time the main process is checking whether the leaving_flag is true, and if so just writes 'waiting_to_leave' into etcd and doesn't go into the FSM.
* if we hit this then it's broken from this point as we then never enter the FSM again as the old and new values are the same

Tested live, fixes #204