### PR TITLE
[Reviewer: Matt] Fix namespace command

### DIFF
--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -47,7 +47,7 @@ def run_command(command, namespace=None, log_error=True):
     passing to this function.
     """
     if namespace:
-        command += "ip netns exec {} ".format(namespace) + command
+        command = "ip netns exec {} ".format(namespace) + command
 
     try:
         output = subprocess.check_output(command,


### PR DESCRIPTION
Stops the command being appended to itself when running cluster manager in multiple networks

Fix for https://github.com/Metaswitch/clearwater-cassandra/issues/58. 