### PR TITLE
[Reviewer: Alex] Lock the PIDfile, to prevent multiple processes running at once

### DIFF
--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -54,7 +54,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
 # We have separate entries for DAEMON and ACTUAL_EXEC:
-# - DAEMON is the command to run to start clearwater-config-manager. We use this when we want to
+# - DAEMON is the command to run to start clearwater-cluster-manager. We use this when we want to
 # start it.
 # - ACTUAL_EXEC is the name which will appear in the process tree after it's been started. We use
 # this when we want to locate currently running instances (to kill them, send a signal to them, or

--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -111,10 +111,10 @@ do_start()
                --log-directory=$log_directory
                --pidfile=$PIDFILE"
 
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $ACTUAL_EXEC --test > /dev/null \
     || return 1
 
-  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --pidfile $PIDFILE --exec $DAEMON -- \
+  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --pidfile $PIDFILE --exec $ACTUAL_EXEC -- \
     $DAEMON_ARGS \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready

--- a/debian/clearwater-config-manager.init.d
+++ b/debian/clearwater-config-manager.init.d
@@ -88,10 +88,10 @@ do_start()
 
   DAEMON_ARGS="--local-ip=${management_local_ip:-$local_ip} --local-site=$local_site_name --log-level=$log_level --log-directory=$log_directory --pidfile=$PIDFILE --etcd-key=$etcd_key"
 
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $ACTUAL_EXEC --test > /dev/null \
     || return 1
 
-  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --pidfile $PIDFILE --exec $ACTUAL_EXEC -- $DAEMON_ARGS \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
   # to handle requests from services started subsequently which depend

--- a/debian/clearwater-config-manager.init.d
+++ b/debian/clearwater-config-manager.init.d
@@ -49,11 +49,21 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC=clearwater-config-manager       # Introduce a short description here
 NAME=clearwater-config-manager       # Introduce the short server's name here (not suitable for --name)
 USER=clearwater-config-manager       # Username to run as
-DAEMON=/usr/share/clearwater/bin/clearwater-config-manager # Introduce the server's location here
-ACTUAL_EXEC=/usr/share/clearwater/clearwater-config-manager/env/bin/python
 DAEMON_DIR=/usr/share/clearwater/clearwater-config-manager/
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
+
+# We have separate entries for DAEMON and ACTUAL_EXEC:
+# - DAEMON is the command to run to start clearwater-config-manager. We use this when we want to
+# start it.
+# - ACTUAL_EXEC is the name which will appear in the process tree after it's been started. We use
+# this when we want to locate currently running instances (to kill them, send a signal to them, or
+# to check if they exist before starting a new process).
+#
+# See also start-stop-daemon's manpage, specifically the comment on --exec: "this might not work as
+# intended with interpreted scripts, as the executable will point to the interpreter". 
+DAEMON=/usr/share/clearwater/bin/clearwater-config-manager
+ACTUAL_EXEC=/usr/share/clearwater/clearwater-config-manager/env/bin/python
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
@@ -88,10 +98,12 @@ do_start()
 
   DAEMON_ARGS="--local-ip=${management_local_ip:-$local_ip} --local-site=$local_site_name --log-level=$log_level --log-directory=$log_directory --pidfile=$PIDFILE --etcd-key=$etcd_key"
 
+  # Check if the process is already running - we use ACTUAL_EXEC here, as that's what will be in the
+  # process tree (not DAEMON).
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $ACTUAL_EXEC --test > /dev/null \
     || return 1
 
-  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --pidfile $PIDFILE --exec $ACTUAL_EXEC -- $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --pidfile $PIDFILE --exec $ACTUAL_EXEC --startas $DAEMON -- $DAEMON_ARGS \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
   # to handle requests from services started subsequently which depend

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -144,12 +144,12 @@ def main(args):
 
     utils.install_sigusr1_handler("cluster-manager")
 
-    # Drop a pidfile. We must keep a reference to pidfile here, as this keeps
-    # the file locked and provides extra protection against two files running at
+    # Drop a pidfile. We must keep a reference to the file object here, as this keeps
+    # the file locked and provides extra protection against two processes running at
     # once.
-    pidfile = None
+    pidfile_lock = None
     try:
-        pidfile = utils.write_pid_file(arguments['--pidfile'])
+        pidfile_lock = utils.lock_and_write_pid_file(arguments['--pidfile']) # noqa
     except IOError:
         # We failed to take the lock - another process is already running
         exit(1)

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -145,9 +145,10 @@ def main(args):
     utils.install_sigusr1_handler("cluster-manager")
 
     # Drop a pidfile.
-    pid = os.getpid()
-    with open(arguments['--pidfile'], "w") as pidfile:
-        pidfile.write(str(pid) + "\n")
+    pidfile = utils.write_pid_file(arguments['--pidfile'])
+    if pidfile is None:
+        # We failed to take the lock - another process is already running
+        exit(1)
 
     plugins_dir = "/usr/share/clearwater/clearwater-cluster-manager/plugins/"
     plugins = load_plugins_in_dir(plugins_dir,

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -144,9 +144,13 @@ def main(args):
 
     utils.install_sigusr1_handler("cluster-manager")
 
-    # Drop a pidfile.
-    pidfile = utils.write_pid_file(arguments['--pidfile'])
-    if pidfile is None:
+    # Drop a pidfile. We must keep a reference to pidfile here, as this keeps
+    # the file locked and provides extra protection against two files running at
+    # once.
+    pidfile = None
+    try:
+        pidfile = utils.write_pid_file(arguments['--pidfile'])
+    except IOError:
         # We failed to take the lock - another process is already running
         exit(1)
 

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -105,9 +105,13 @@ def main(args):
 
     utils.install_sigusr1_handler("config-manager")
 
-    # Drop a pidfile.
-    pidfile = utils.write_pid_file(arguments['--pidfile'])
-    if pidfile is None:
+    # Drop a pidfile. We must keep a reference to pidfile here, as this keeps
+    # the file locked and provides extra protection against two files running at
+    # once.
+    pidfile = None
+    try:
+        pidfile = utils.write_pid_file(arguments['--pidfile'])
+    except IOError:
         # We failed to take the lock - another process is already running
         exit(1)
 

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -106,9 +106,10 @@ def main(args):
     utils.install_sigusr1_handler("config-manager")
 
     # Drop a pidfile.
-    pid = os.getpid()
-    with open(arguments['--pidfile'], "w") as pidfile:
-        pidfile.write(str(pid) + "\n")
+    pidfile = utils.write_pid_file(arguments['--pidfile'])
+    if pidfile is None:
+        # We failed to take the lock - another process is already running
+        exit(1)
 
     plugins_dir = "/usr/share/clearwater/clearwater-config-manager/plugins/"
     plugins = load_plugins_in_dir(plugins_dir)

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -105,12 +105,12 @@ def main(args):
 
     utils.install_sigusr1_handler("config-manager")
 
-    # Drop a pidfile. We must keep a reference to pidfile here, as this keeps
-    # the file locked and provides extra protection against two files running at
+    # Drop a pidfile. We must keep a reference to the file object here, as this keeps
+    # the file locked and provides extra protection against two processes running at
     # once.
-    pidfile = None
+    pidfile_lock = None
     try:
-        pidfile = utils.write_pid_file(arguments['--pidfile'])
+        pidfile_lock = utils.lock_and_write_pid_file(arguments['--pidfile']) # noqa
     except IOError:
         # We failed to take the lock - another process is already running
         exit(1)


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/clearwater-etcd/issues/218 along with https://github.com/Metaswitch/python-common/pull/31. I've tested live:

```
/var/log/clearwater-cluster-manager/cluster-manager_20151027T170000Z.txt:27-10-2015 17:38:32.560 UTC INFO utils.py:411 (thread MainThread): Acquired exclusive lock on /var/run/clearwater-cluster-manager.pid
/var/log/clearwater-cluster-manager/cluster-manager_20151027T170000Z.txt:27-10-2015 17:38:42.055 UTC ERROR utils.py:413 (thread MainThread): Lock on /var/run/clearwater-cluster-manager.pid is held by another process
/var/log/clearwater-cluster-manager/cluster-manager_20151027T170000Z.txt:27-10-2015 17:38:57.978 UTC ERROR utils.py:413 (thread MainThread): Lock on /var/run/clearwater-cluster-manager.pid is held by another process
/var/log/clearwater-cluster-manager/cluster-manager_20151027T170000Z.txt:27-10-2015 17:38:58.828 UTC ERROR utils.py:413 (thread MainThread): Lock on /var/run/clearwater-cluster-manager.pid is held by another process
/var/log/clearwater-cluster-manager/cluster-manager_20151027T170000Z.txt:27-10-2015 17:38:59.462 UTC ERROR utils.py:413 (thread MainThread): Lock on /var/run/clearwater-cluster-manager.pid is held by another process
/var/log/clearwater-cluster-manager/cluster-manager_20151027T170000Z.txt:27-10-2015 17:38:59.970 UTC ERROR utils.py:413 (thread MainThread): Lock on /var/run/clearwater-cluster-manager.pid is held by another process
/var/log/clearwater-cluster-manager/cluster-manager_20151027T170000Z.txt:27-10-2015 17:39:00.394 UTC ERROR utils.py:413 (thread MainThread): Lock on /var/run/clearwater-cluster-manager.pid is held by another process
```

I can't think of any other process that need this (most acquire another sort of exclusive resource, e.g. by listening on a port). Let me know if you can.