### PR TITLE
[Reviewer: Graeme] Translate UTF-8 files to a series of bytes for MD5 encoding

### DIFF
--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -60,7 +60,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 _log.info("Got new config value from etcd - filename {}, file size {}, MD5 hash {}".format(
                     self._plugin.file(),
                     len(value),
-                    md5(value).hexdigest()))
+                    md5(value.encode("utf-8", errors="replace")).hexdigest()))
                 _log.debug("Got new config value from etcd:\n{}".format(value))
                 self._plugin.on_config_changed(value, self._alarm)
                 FILE_CHANGED.log(filename=self._plugin.file())


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/clearwater-etcd/issues/169 (following guidance in https://docs.python.org/2/howto/unicode.html#python-2-x-s-unicode-support), and sets errors="replace" so we don't get exceptions on non-UTF8 characters.