### PR TITLE
[Reviewer: Rob] Add root permissions check

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config
@@ -32,6 +32,12 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+if [[ $EUID -ne 0 ]]
+then
+  echo "You must run this script with root permissions"
+  exit 1
+fi
+
 [ $# -le 1 ] || { echo "Usage: apply_shared_config [--sync]" >&2 ; exit 2 ; }
 
 FILENAME=/etc/clearwater/shared_config.apply


### PR DESCRIPTION
apply_shared_config directly needs root permissions, so exit with a useful error if we don't have them