### PR TITLE
[Reviewer: Ellie] Fixes to cope with unstarted etcd nodes

### DIFF
--- a/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
+++ b/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
@@ -1,3 +1,37 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
 import httplib
 import json
 import sys

--- a/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
+++ b/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
@@ -1,0 +1,23 @@
+import httplib
+import json
+import sys
+
+def main(ip, servers):
+    my_url = "http://{}:2380".format(ip)
+    for s in servers.split(","):
+        try:
+            cxn = httplib.HTTPConnection(s, 4000)
+            cxn.request("GET", "/v2/members?consistent=false");
+            member_data = json.loads(cxn.getresponse().read())
+            for m in member_data['members']:
+                if not m['name']:
+                    m['name'] = str(uuid.uuid4())
+            cluster = ",".join(["{}={}".format(m['name'], m['peerURLs'][0]) for m in member_data['members'] if m['peerURLs'][0] != my_url])
+            print "{}".format(cluster)
+            return
+        except OSError:
+            pass
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2]
+

--- a/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
+++ b/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
@@ -35,9 +35,11 @@
 import httplib
 import json
 import sys
+import uuid
 
 def main(ip, servers):
     my_url = "http://{}:2380".format(ip)
+    my_name = ip.replace(".", "-")
     for s in servers.split(","):
         try:
             cxn = httplib.HTTPConnection(s, 4000)
@@ -46,12 +48,13 @@ def main(ip, servers):
             for m in member_data['members']:
                 if not m['name']:
                     m['name'] = str(uuid.uuid4())
-            cluster = ",".join(["{}={}".format(m['name'], m['peerURLs'][0]) for m in member_data['members'] if m['peerURLs'][0] != my_url])
+            members = ["{}={}".format(m['name'], m['peerURLs'][0]) for m in member_data['members'] if m['peerURLs'][0] != my_url] + ["{}={}".format(my_name, my_url)]
+            cluster = ",".join(members)
             print "{}".format(cluster)
             return
         except OSError:
             pass
 
 if __name__ == "__main__":
-    main(sys.argv[1], sys.argv[2]
+    main(sys.argv[1], sys.argv[2])
 

--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -130,22 +130,19 @@ join_cluster()
          then
            echo "Not joining an unhealthy cluster"
            exit 2
-         fi
-        # Tell the cluster we're joining, this prints useful environment
-        # variables to stdout but also prints a success message so strip that
-        # out before saving the variables to the temp file.
-        /usr/bin/etcdctl member add $ETCD_NAME http://$advertisement_ip:2380 | grep -v "Added member" >> $TEMP_FILE
+        fi
+
+        # Tell the cluster we're joining
+        /usr/bin/etcdctl member add $ETCD_NAME http://$advertisement_ip:2380
         if [[ $? != 0 ]]
         then
           echo "Failed to add local node to cluster"
           exit 2
         fi
+        ETCD_INITIAL_CLUSTER=$(/usr/share/clearwater/bin/get_etcd_initial_cluster.py $local_ip $etcd_cluster)
 
-        # Load the environment variables back into the local shell and export
-        # them so ./etcd can see them when it starts up.
-        . $TEMP_FILE
         CLUSTER_ARGS="--initial-cluster $ETCD_INITIAL_CLUSTER
-                      --initial-cluster-state $ETCD_INITIAL_CLUSTER_STATE"
+                      --initial-cluster-state existing"
 
         # daemon is not running, so attempt to start it.
         ulimit -Hn 10000


### PR DESCRIPTION
(I know you're relatively busy this sprint, but as you added the existing code to cope with unstarted state in the init.d script and you've looked at #203, you're probably well-placed to review - and it's not urgent.)

This fixes https://github.com/Metaswitch/clearwater-etcd/issues/203 in two ways:

- we delete our data dir if we're in unstarted state - previously this code was in join_cluster(), which was only run if we didn't have a datadir, so I think it was unhittable. (I've also dropped the 'member remove' code here - I think deleting the datadir is sufficient.)
- if we have multiple nodes in unstarted state (i.e. with no name) we generate a UUID to use as the name to stop them clashing. (I've done this by calling out to a Python script, which also simplifies some of the shell wrangling).

I've tested the general idea of the fix in FV, but I'll spin up a live system to make sure I haven't broken anything with a typo. I'm not going to try and repro #203 live - shout if you think I should.