### PR TITLE
[Reviewer: Andy] Minimal regressible etcd testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ X86_64_ONLY=0
 
 .DEFAULT_GOAL = deb
 
+.PHONY: fvtest
+fvtest: fvtest_setup.py env
+	PYTHONPATH=src:common ${ENV_PYTHON} fvtest_setup.py test -v
+
 .PHONY: test
 test: coverage
 

--- a/fvtest_setup.py
+++ b/fvtest_setup.py
@@ -1,0 +1,46 @@
+# @file setup.py
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import logging
+import sys
+import multiprocessing
+
+from setuptools import setup, find_packages
+
+setup(
+    name='clearwater-etcd-tests',
+    version='1.0',
+    test_suite='metaswitch.clearwater.etcd_tests',
+    tests_require=['python-etcd'],
+    )

--- a/src/metaswitch/clearwater/etcd_tests/etcdserver.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdserver.py
@@ -1,0 +1,115 @@
+from subprocess import Popen, PIPE, STDOUT
+import httplib
+import json
+from time import sleep
+from signal import SIGTERM, SIGABRT
+import shlex
+import etcd
+from shutil import rmtree
+
+base_cmd =              """clearwater-etcd/usr/bin/etcd --debug --listen-client-urls http://{0}:4000 --advertise-client-urls http://{0}:4000 --listen-peer-urls http://{0}:2380 --initial-advertise-peer-urls http://{0}:2380 --data-dir {2}/{1} --name {1}"""
+
+first_member_cmd =      base_cmd + """ --initial-cluster-state new --initial-cluster {1}=http://{0}:2380"""
+subsequent_member_cmd = base_cmd + """ --initial-cluster-state existing --initial-cluster {3},{1}=http://{0}:2380"""
+
+class EtcdServer(object):
+    datadir = "./etcd_test_data"
+
+
+    @classmethod
+    def delete_datadir(cls):
+        rmtree(cls.datadir)
+
+    def __init__(self, ip, existing=None, replacement=False):
+        self._ip = ip
+        self._exit_signal = SIGTERM
+        name = ip.replace(".", "-")
+
+        logfile = open("etcd-{}.log".format(ip), "w")
+
+        if existing is None:
+            self._subprocess = Popen(shlex.split(first_member_cmd.format(ip, name, EtcdServer.datadir)),
+                                     stdout=logfile,
+                                     stderr=STDOUT
+                                     )
+        else:
+            my_url = "http://{}:2380".format(ip)
+            cxn = httplib.HTTPConnection(existing, 4000)
+            if not replacement:
+                cxn.request("POST",
+                            "/v2/members",
+                            json.dumps({"name": name, "peerURLs": [my_url]}),
+                            {"Content-Type": "application/json"})
+                me = json.loads(cxn.getresponse().read())
+                self._id = me['id']
+
+            cxn.request("GET", "/v2/members?consistent=false");
+            member_data = json.loads(cxn.getresponse().read())
+            cluster = ",".join(["{}={}".format(m['name'], m['peerURLs'][0]) for m in member_data['members'] if m['peerURLs'][0] != my_url])
+            self._subprocess = Popen(shlex.split(subsequent_member_cmd.format(ip, name, EtcdServer.datadir, cluster)),
+                                     stdout=logfile,
+                                     stderr=STDOUT
+                                     )
+
+    def cluster_id(self):
+        if self._id is None:
+            members = self.memberList()
+            pass
+        return self._id
+
+    def isAlive(self):
+        try:
+            return self.write_test_key()
+        except (IOError, ValueError):
+            return False
+
+    def waitUntilAlive(self):
+        for _ in range(50):
+            if self.isAlive():
+                return True
+            else:
+                sleep(0.1)
+        return False
+
+    def write_test_key(self):
+        cxn = httplib.HTTPConnection(self._ip, 4000)
+        cxn.request("PUT",
+                    "/v2/keys/init_test",
+                    "hello world")
+        rsp = cxn.getresponse()
+        return ((rsp.status == 200) or (rsp.status == 201))
+
+    def isLeader(self):
+        cxn = httplib.HTTPConnection(self._ip, 4000)
+        cxn.request("GET", "/v2/stats/self");
+        rsp = cxn.getresponse().read()
+        return json.loads(rsp)['state'] == "stateLeader"
+
+    def __del__(self):
+        # Kill the etcd subprocess on destruction
+        self.exit()
+
+    def memberList(self):
+        cxn = httplib.HTTPConnection(self._ip, 4000)
+        cxn.request("GET", "/v2/members");
+        return json.loads(cxn.getresponse().read())['members']
+
+    def exit(self):
+        if self._subprocess:
+            self._subprocess.send_signal(self._exit_signal)
+            self._subprocess.communicate()
+            self._subprocess = None
+
+    def crash(self):
+        if self._subprocess:
+            self._subprocess.send_signal(SIGABRT)
+            self._subprocess.communicate()
+            self._subprocess = None
+
+    def delete(self, peer):
+        cxn = httplib.HTTPConnection(peer, 4000)
+        cxn.request("DELETE", "/v2/members/{}".format(self._id));
+        cxn.getresponse().read()
+
+    def client(self):
+        return etcd.Client(self._ip, port=4000)

--- a/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
@@ -1,0 +1,77 @@
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+from time import sleep
+import logging
+import sys
+import etcd
+from threading import Thread
+import unittest
+import json
+from .etcdserver import EtcdServer
+
+logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
+logging.getLogger().setLevel(logging.INFO)
+
+class EtcdTestBase(unittest.TestCase):
+    def setUp(self):
+        self.servers = {}
+        self.pool = ["127.0.0.{}".format(last_byte)  for last_byte in range (100, 150)]
+
+    def add_server(self, **kwargs):
+        ip = self.pool.pop()
+        server = EtcdServer(ip, **kwargs)
+        self.servers[ip] = server
+        return server
+
+    def initialise_servers(self, n):
+        ret = []
+        srv1 = self.add_server()
+        ret.append(srv1)
+        srv1.waitUntilAlive()
+        for _ in range(n-1):
+            ret.append(self.add_server(existing=srv1._ip))
+        [x.waitUntilAlive() for x in ret]
+        return ret
+
+    def tearDown(self):
+        for server in self.servers.values():
+            server.exit()
+        EtcdServer.delete_datadir()
+
+    def test_basic_clustering(self):
+        s1, s2 = self.initialise_servers(2)
+
+        hasOneLeader = s1.isLeader() != s2.isLeader()
+
+        self.assertTrue(s1.memberList() == s2.memberList())
+        self.assertEquals(2, len(s1.memberList()))


### PR DESCRIPTION
I've trimmed #142 back to its core, and tidied that core up a bit. This adds:

- an EtcdServer and an EtcdCluster class, giving a Python interface to etcd and its HTTP API
- two tests - one very simple (creating two nodes, checking they agree on the cluster view) and one more complicated (reproducing #203)
- a 'make fvtest' command to run them

My main concern here is that my EtcdServer doesn't necessarily match up with what our init.d script does. I think the right approach here is to move the logic in the init.d script out into Python helper scripts, which can then be common between live and FV etcds - as I've started to do with #225 .