### PR TITLE
[Reviewer: Matt] Don't remove pidfiles without a lock, and set the process name with prctl

### DIFF
--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.cluster_manager.test',
-    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "futures", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "futures", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.config_manager.test',
-    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt", "python-etcd", "pyzmq", "pyyaml", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -145,9 +145,6 @@ do_stop()
 	#   other if a failure occurred
 	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
 	RETVAL="$?"
-	[ "$RETVAL" = 2 ] && return 2
-	# Many daemons don't delete their pidfiles when they exit.
-	rm -f $PIDFILE
 	return "$RETVAL"
 }
 
@@ -163,9 +160,6 @@ do_decommission()
 	#   other if a failure occurred
 	start-stop-daemon --stop --quiet --retry=QUIT/1200 --exec $ACTUAL_EXEC --pidfile $PIDFILE
 	RETVAL="$?"
-	[ "$RETVAL" = 2 ] && return 2
-	# Many daemons don't delete their pidfiles when they exit.
-	rm -f $PIDFILE
 	return "$RETVAL"
 }
 
@@ -184,9 +178,6 @@ do_abort()
         #   other if a failure occurred
         start-stop-daemon --stop --quiet --retry=USR1/5/TERM/30/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
         RETVAL="$?"
-        [ "$RETVAL" = 2 ] && return 2
-        # Many daemons don't delete their pidfiles when they exit.
-        rm -f $PIDFILE
         return "$RETVAL"
 }
 

--- a/debian/clearwater-config-manager.init.d
+++ b/debian/clearwater-config-manager.init.d
@@ -122,9 +122,6 @@ do_stop()
 	#   other if a failure occurred
 	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
 	RETVAL="$?"
-	[ "$RETVAL" = 2 ] && return 2
-	# Many daemons don't delete their pidfiles when they exit.
-	rm -f $PIDFILE
 	return "$RETVAL"
 }
 
@@ -142,9 +139,6 @@ do_abort()
         #   other if a failure occurred
         start-stop-daemon --stop --quiet --retry=USR1/5/TERM/30/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
         RETVAL="$?"
-        [ "$RETVAL" = 2 ] && return 2
-        # Many daemons don't delete their pidfiles when they exit.
-        rm -f $PIDFILE
         return "$RETVAL"
 }
 

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -64,6 +64,7 @@ from metaswitch.clearwater.cluster_manager.plugin_base import PluginParams
 from metaswitch.clearwater.cluster_manager import pdlogs
 import logging
 import os
+import prctl
 import syslog
 from threading import activeCount
 from time import sleep
@@ -133,6 +134,9 @@ def main(args):
 
     if not arguments['--foreground']:
         utils.daemonize(stdout_err_log)
+
+    # Process names are limited to 15 characters, so abbreviate
+    prctl.prctl(prctl.NAME, "cw-cluster-mgr")
 
     logging_config.configure_logging(log_level, log_dir, "cluster-manager", show_thread=True)
 

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -63,6 +63,7 @@ from metaswitch.clearwater.config_manager import pdlogs
 import syslog
 import logging
 import os
+import prctl
 from threading import Thread
 
 _log = logging.getLogger("config_manager.main")
@@ -94,6 +95,9 @@ def main(args):
 
     if not arguments['--foreground']:
         utils.daemonize(stdout_err_log)
+
+    # Process names are limited to 15 characters, so abbreviate
+    prctl.prctl(prctl.NAME, "cw-config-mgr")
 
     logging_config.configure_logging(log_level, log_dir, "config-manager", show_thread=True)
 


### PR DESCRIPTION
This PR:

* deletes the places where the init script would delete the pidfile without locking it
* renames the process from "python" to "cw-cluster-mgr" or "cw-config-mgr" - not for start-stop-daemon purposes, but for diagnostics
* adds prctl as a dependency

(We already created and used a pidfile for monitoring, and there are no subprocesses.)