### PR TITLE
[Reviewer: Andy] Build the different .egg files in different directories to avoid conf…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ build-eggs: ${ENV_DIR}/.cluster-mgr-build-eggs ${ENV_DIR}/.config-mgr-build-eggs
 
 ${ENV_DIR}/.config-mgr-build-eggs: config_mgr_setup.py shared_setup.py common/setup.py $(shell find src/metaswitch -type f -not -name "*.pyc") $(shell find common/metaswitch -type f -not -name "*.pyc") src/metaswitch/clearwater/config_manager/alarm_constants.py
 	# Generate .egg files
-	${ENV_DIR}/bin/python config_mgr_setup.py bdist_egg -d config_mgr_eggs
-	${ENV_DIR}/bin/python shared_setup.py bdist_egg -d config_mgr_eggs
+	${ENV_DIR}/bin/python config_mgr_setup.py build -b build_configmgr bdist_egg -d config_mgr_eggs
+	${ENV_DIR}/bin/python shared_setup.py build -b build_shared bdist_egg -d config_mgr_eggs
 	cd common && EGG_DIR=../config_mgr_eggs make build_common_egg
 
 	# Download the egg files they depend upon
@@ -73,8 +73,8 @@ ${ENV_DIR}/.config-mgr-build-eggs: config_mgr_setup.py shared_setup.py common/se
 
 ${ENV_DIR}/.cluster-mgr-build-eggs: cluster_mgr_setup.py shared_setup.py common/setup.py $(shell find src/metaswitch -type f -not -name "*.pyc") $(shell find common/metaswitch -type f -not -name "*.pyc") src/metaswitch/clearwater/cluster_manager/alarm_constants.py
 	# Generate .egg files
-	${ENV_DIR}/bin/python cluster_mgr_setup.py bdist_egg -d cluster_mgr_eggs
-	${ENV_DIR}/bin/python shared_setup.py bdist_egg -d cluster_mgr_eggs
+	${ENV_DIR}/bin/python cluster_mgr_setup.py build -b build_clustermgr bdist_egg -d cluster_mgr_eggs
+	${ENV_DIR}/bin/python shared_setup.py build -b build_shared bdist_egg -d cluster_mgr_eggs
 	cd common && EGG_DIR=../cluster_mgr_eggs make build_common_egg 
 
 	# Download the egg files they depend upon
@@ -99,6 +99,7 @@ clean: envclean pyclean
 pyclean:
 	find src -name \*.pyc -exec rm -f {} \;
 	rm -rf src/*.egg-info dist
+	rm -rf build build_configmgr build_clustermgr build_shared
 	rm -f .coverage
 	rm -rf htmlcov/
 


### PR DESCRIPTION
…lict

Tested:

```
$ find build_*
build_clustermgr
build_clustermgr/bdist.linux-x86_64
build_clustermgr/lib.linux-x86_64-2.7
build_clustermgr/lib.linux-x86_64-2.7/metaswitch
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/plugin_base.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/pdlogs.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/plugin_utils.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/main.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/alarms.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/cluster_state.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/alarm_constants.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/null_plugin.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/constants.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/__init__.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/clearwater/__init__.py
build_clustermgr/lib.linux-x86_64-2.7/metaswitch/__init__.py
build_configmgr
build_configmgr/bdist.linux-x86_64
build_configmgr/lib.linux-x86_64-2.7
build_configmgr/lib.linux-x86_64-2.7/metaswitch
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/plugin_base.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/etcd_synchronizer.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/pdlogs.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/main.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/alarms.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/alarm_constants.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/__init__.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/clearwater/__init__.py
build_configmgr/lib.linux-x86_64-2.7/metaswitch/__init__.py
build_shared
build_shared/bdist.linux-x86_64
build_shared/lib.linux-x86_64-2.7
build_shared/lib.linux-x86_64-2.7/metaswitch
build_shared/lib.linux-x86_64-2.7/metaswitch/clearwater
build_shared/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared
build_shared/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/plugin_utils.py
build_shared/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/plugin_loader.py
build_shared/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
build_shared/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/__init__.py
build_shared/lib.linux-x86_64-2.7/metaswitch/clearwater/__init__.py
build_shared/lib.linux-x86_64-2.7/metaswitch/__init__.py
```

vs. the repo server:

```
# find build
build
build/lib.linux-x86_64-2.7
build/lib.linux-x86_64-2.7/metaswitch
build/lib.linux-x86_64-2.7/metaswitch/clearwater
build/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared
build/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/plugin_utils.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/__init__.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/etcd_shared/plugin_loader.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/alarm_constants.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/plugin_base.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/constants.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/null_plugin.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/alarms.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/main.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/pdlogs.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/cluster_state.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/plugin_utils.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/cluster_manager/__init__.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/alarm_constants.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/plugin_base.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/alarms.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/main.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/pdlogs.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/etcd_synchronizer.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/config_manager/__init__.py
build/lib.linux-x86_64-2.7/metaswitch/clearwater/__init__.py
build/lib.linux-x86_64-2.7/metaswitch/__init__.py
build/bdist.linux-x86_64
```
