### PR TITLE
[Reviewer: Ellie] Set etcd-managed files to have 0644 permissions, not 0600

### DIFF
--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -67,7 +67,7 @@ def run_command(command, namespace=None, log_error=True):
                                                          e.output))
         return e.returncode
 
-def safely_write(filename, contents):
+def safely_write(filename, contents, permissions=0644):
     """Writes a file without race conditions, by writing to a temporary file and then atomically renaming it"""
 
     # Create the temporary file in the same directory (to ensure it's on the
@@ -76,5 +76,7 @@ def safely_write(filename, contents):
     tmp = tempfile.NamedTemporaryFile(dir=dirname(filename), delete=False)
 
     tmp.write(contents)
+
+    os.chmod(tmp.name, permissions)
 
     os.rename(tmp.name, filename)


### PR DESCRIPTION
https://github.com/Metaswitch/clearwater-etcd/pull/223 had one slight side-effect - it set all the etcd-managed file permissions to 0600. This sets them to a more normal 0644.