### PR TITLE
[Reviewer: Graeme] Use correct alarm

### DIFF
--- a/clearwater-queue-manager.root/usr/share/clearwater/conf/clearwater-queue-manager.monit
+++ b/clearwater-queue-manager.root/usr/share/clearwater/conf/clearwater-queue-manager.monit
@@ -3,15 +3,15 @@
 # Monitor the service's PID file and memory use.
 check process clearwater_queue_manager with pidfile /var/run/clearwater-queue-manager.pid
 
-  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 6500.3; /etc/init.d/clearwater-queue-manager start'"
-  stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 6500.3; /etc/init.d/clearwater-queue-manager stop'"
-  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 6500.3; /etc/init.d/clearwater-queue-manager restart'"
+  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 9000.3; /etc/init.d/clearwater-queue-manager start'"
+  stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 9000.3; /etc/init.d/clearwater-queue-manager stop'"
+  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 9000.3; /etc/init.d/clearwater-queue-manager restart'"
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a (dummy) core file and trigger diagnostics collection.
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 6500.3; /etc/init.d/clearwater-queue-manager abort'"
+  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 9000.3; /etc/init.d/clearwater-queue-manager abort'"
 
   # Clear any alarms if the process has been running for 30 seconds
   if uptime < 30 seconds
      then exec "/bin/true"
-     else if succeeded then exec "/usr/share/clearwater/bin/issue_alarm.py monit 6500.1"
+     else if succeeded then exec "/usr/share/clearwater/bin/issue_alarm.py monit 9000.1"

--- a/src/metaswitch/clearwater/queue_manager/plugin_base.py
+++ b/src/metaswitch/clearwater/queue_manager/plugin_base.py
@@ -52,7 +52,7 @@ class QueuePluginBase(object): # pragma : no cover
         return (alarm_constants.GLOBAL_CONFIG_RESYNCHING_CLEARED,
                 alarm_constants.GLOBAL_CONFIG_RESYNCHING_MINOR,
                 alarm_constants.GLOBAL_CONFIG_RESYNCHING_CRITICAL,
-                "local")
+                "global")
 
     @abstractmethod
     def key(self):


### PR DESCRIPTION
Use the queue manager alarm. Also fix up the global alarm text. 

Tested live

Fixes #251 