### PR TITLE
[Reviewer: Graeme] Stop restarting so often and fix timers

### DIFF
--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -52,11 +52,12 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
             # This blocks on changes to the watched key in etcd.
             _log.debug("Waiting for change from etcd for key {}".format(
                          self._plugin.key()))
+            old_value = self._last_value
             value = self.update_from_etcd()
             if self._terminate_flag:
                 break
 
-            if value:
+            if value and value != old_value:
                 _log.info("Got new config value from etcd - filename {}, file size {}, MD5 hash {}".format(
                     self._plugin.file(),
                     len(value),

--- a/src/metaswitch/clearwater/queue_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/queue_manager/etcd_synchronizer.py
@@ -157,7 +157,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
             # Our etcd write failed because someone got there before us. We
             # don't need to retry in this case as we'll just pick up the
             # changes in the next etcd read
-            self._last_value, self._last_index = None, None
+            self._last_value, self._last_index, self._fsm._last_local_state = None, None, None
             rc = WriteToEtcdStatus.CONTENTION
         except Exception as e: #pragma: no cover
             # Catch-all error handler (for invalid requests, timeouts, etc) -
@@ -170,7 +170,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
             # read from etcd will trigger the state machine, which will mean
             # that any necessary work/state changes get retried.
             # Sleep briefly to avoid hammering a failed server
-            self._last_value, self._last_index = None, None
+            self._last_value, self._last_index, self._fsm._last_local_state = None, None, None
             self.pause()
             rc = WriteToEtcdStatus.ERROR
      


### PR DESCRIPTION
Graeme, can you review these fixes to improve the stability of the queue manager
The fixes:
* Stop the config manager from adding the node to the queue if the config file hasn't changed
* Make sure that the timers are cleared before reuse
* Stop a local state action from being repeated

Tested live

These fixes are linked to #249