### PR TITLE
[Reviewer: Andy] Fix up cluster managers postinst/prerm

### DIFF
--- a/debian/clearwater-cluster-manager.postinst
+++ b/debian/clearwater-cluster-manager.postinst
@@ -58,23 +58,16 @@ case "$1" in
         if ! grep -q "^$NAME:" /etc/passwd ; then
             useradd --system -M -d /nonexistent -s /bin/false $NAME
         fi
+
         # Ensure the log directory exists and is owned by the user.
         mkdir -p -m 755 /var/log/$NAME
         chown -R $NAME:root /var/log/$NAME
 
+        # Set up the virtual env
         virtualenv --python=$(which python) $BASE_DIR/env
         $BASE_DIR/env/bin/easy_install --allow-hosts=None -f $BASE_DIR/eggs/ $BASE_DIR/eggs/clearwater_cluster_manager-1.0-py2.7.egg
         chown -R $NAME:root $BASE_DIR/env
         
-        mkdir -p $BASE_DIR/plugins
-        chown -R root:root $BASE_DIR/plugins
-        chmod 644 $BASE_DIR/plugins
-
-        # Restart the alarm agent
-        if [ -x "/etc/init.d/clearwater-snmp-alarm-agent" ]; then
-          service clearwater-snmp-alarm-agent stop || /bin/true
-        fi
-
         # Start monit monitoring
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-cluster-manager.monit /etc/monit/conf.d/        
         reload clearwater-monit || true

--- a/debian/clearwater-cluster-manager.prerm
+++ b/debian/clearwater-cluster-manager.prerm
@@ -56,18 +56,22 @@ case "$1" in
         # Stop monitoring the process
         rm -f /etc/monit/conf.d/clearwater-cluster-manager.monit
         reload clearwater-monit &> /dev/null || true
+
         # Make sure the process is stopped - do this before env is removed,
         # or init.d script won't work
         service clearwater-cluster-manager stop
+
         # Now do necessary cleanup
         rm -rf $BASE_DIR/env
         rm -rf /var/run/$NAME
 
-        # Don't remove the user if we're just upgrading.
+        # Don't remove the user/logs if we're just upgrading.
         if [ $1 != "upgrade" ]; then
           if grep -q "^$NAME:" /etc/passwd ; then
             userdel $NAME
           fi
+
+          rm -rf /var/log/$NAME
         fi
     ;;
 

--- a/debian/clearwater-cluster-manager.triggers
+++ b/debian/clearwater-cluster-manager.triggers
@@ -1,0 +1,1 @@
+activate clearwater-snmp-alarm-agent

--- a/debian/clearwater-config-manager.postinst
+++ b/debian/clearwater-config-manager.postinst
@@ -58,22 +58,15 @@ case "$1" in
         if ! grep -q "^$NAME:" /etc/passwd ; then
             useradd --system -M -d /nonexistent -s /bin/false $NAME
         fi
+
         # Ensure the log directory exists and is owned by the user.
         mkdir -p -m 755 /var/log/$NAME
         chown -R $NAME:root /var/log/$NAME
 
+        # Set up the virtual env
         virtualenv --python=$(which python) $BASE_DIR/env
         $BASE_DIR/env/bin/easy_install --allow-hosts=None -f $BASE_DIR/eggs/ $BASE_DIR/eggs/clearwater_config_manager-1.0-py2.7.egg
         chown -R $NAME:root $BASE_DIR/env
-
-        mkdir -p $BASE_DIR/plugins
-        chown -R root:root $BASE_DIR/plugins
-        chmod 644 $BASE_DIR/plugins
-
-        # Restart the alarm agent
-        if [ -x "/etc/init.d/clearwater-snmp-alarm-agent" ]; then
-          service clearwater-snmp-alarm-agent stop || /bin/true
-        fi
 
         # Start monit monitoring
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-config-manager.monit /etc/monit/conf.d/

--- a/debian/clearwater-config-manager.prerm
+++ b/debian/clearwater-config-manager.prerm
@@ -56,9 +56,11 @@ case "$1" in
         # Stop monitoring the process
         rm -f /etc/monit/conf.d/clearwater-config-manager.monit
         reload clearwater-monit &> /dev/null || true
+
         # Make sure the process is stopped - do this before env is removed,
         # or init.d script won't work
         service clearwater-config-manager stop
+
         # Now do necessary cleanup
         rm -rf $BASE_DIR/env
         rm -rf /var/run/$NAME
@@ -68,6 +70,8 @@ case "$1" in
           if grep -q "^$NAME:" /etc/passwd ; then
             userdel $NAME
           fi
+
+          rm -rf /var/log/$NAME
         fi
     ;;
 

--- a/debian/clearwater-config-manager.triggers
+++ b/debian/clearwater-config-manager.triggers
@@ -1,0 +1,1 @@
+activate clearwater-snmp-alarm-agent

--- a/debian/clearwater-etcd.postinst
+++ b/debian/clearwater-etcd.postinst
@@ -89,11 +89,6 @@ case "$1" in
         setup_data_dir
         setup_log_dir
 
-        # Restart the alarm agent
-        if [ -x "/etc/init.d/clearwater-snmp-alarm-agent" ]; then
-          service clearwater-snmp-alarm-agent stop || /bin/true
-        fi
-
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-etcd.monit /etc/monit/conf.d/
         reload clearwater-monit || /bin/true
 

--- a/debian/clearwater-etcd.prerm
+++ b/debian/clearwater-etcd.prerm
@@ -60,6 +60,17 @@ case "$1" in
     upgrade|deconfigure|remove)
         rm -f /etc/monit/conf.d/$NAME.monit
         reload clearwater-monit &> /dev/null || true
+
+        # Now do necessary cleanup. Don't remove the
+        # user/logs/data dir if we're just upgrading.
+        if [ $1 != "upgrade" ]; then
+          if grep -q "^$NAME:" /etc/passwd ; then
+            userdel $NAME
+          fi
+
+          rm -rf /var/log/$NAME
+          rm -rf /var/lib/$NAME
+        fi
     ;;
 
     failed-upgrade)

--- a/debian/clearwater-etcd.prerm
+++ b/debian/clearwater-etcd.prerm
@@ -61,6 +61,9 @@ case "$1" in
         rm -f /etc/monit/conf.d/$NAME.monit
         reload clearwater-monit &> /dev/null || true
 
+        # Make sure the process is stopped
+        service clearwater-etcd stop
+
         # Now do necessary cleanup. Don't remove the
         # user/logs/data dir if we're just upgrading.
         if [ $1 != "upgrade" ]; then

--- a/debian/clearwater-etcd.triggers
+++ b/debian/clearwater-etcd.triggers
@@ -1,0 +1,1 @@
+activate clearwater-snmp-alarm-agent

--- a/debian/clearwater-queue-manager.postinst
+++ b/debian/clearwater-queue-manager.postinst
@@ -58,21 +58,15 @@ case "$1" in
         if ! grep -q "^$NAME:" /etc/passwd ; then
             useradd --system -M -d /nonexistent -s /bin/false $NAME
         fi
+
         # Ensure the log directory exists and is owned by the user.
         mkdir -p -m 755 /var/log/$NAME
         chown -R $NAME:root /var/log/$NAME
 
+        # Set up the virtual env
         virtualenv --python=$(which python) $BASE_DIR/env
         $BASE_DIR/env/bin/easy_install --allow-hosts=None -f $BASE_DIR/eggs/ $BASE_DIR/eggs/clearwater_queue_manager-1.0-py2.7.egg
         chown -R $NAME:root $BASE_DIR/env
-
-        mkdir -p -m 755 $BASE_DIR/plugins
-        chown -R root:root $BASE_DIR/plugins
-
-        # Restart the alarm agent
-        if [ -x "/etc/init.d/clearwater-snmp-alarm-agent" ]; then
-          service clearwater-snmp-alarm-agent stop || /bin/true
-        fi
 
         # Start monit monitoring
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-queue-manager.monit /etc/monit/conf.d/

--- a/debian/clearwater-queue-manager.prerm
+++ b/debian/clearwater-queue-manager.prerm
@@ -56,9 +56,11 @@ case "$1" in
         # Stop monitoring the process
         rm -f /etc/monit/conf.d/clearwater-queue-manager.monit
         reload clearwater-monit &> /dev/null || true
+
         # Make sure the process is stopped - do this before env is removed,
         # or init.d script won't work
         service clearwater-queue-manager stop
+
         # Now do necessary cleanup
         rm -rf $BASE_DIR/env
         rm -rf /var/run/$NAME
@@ -68,6 +70,8 @@ case "$1" in
           if grep -q "^$NAME:" /etc/passwd ; then
             userdel $NAME
           fi
+
+          rm -rf /var/log/$NAME
         fi
     ;;
 

--- a/debian/clearwater-queue-manager.triggers
+++ b/debian/clearwater-queue-manager.triggers
@@ -1,0 +1,1 @@
+activate clearwater-snmp-alarm-agent


### PR DESCRIPTION
Changes to the cluster manager to use the alarm agent trigger (see https://github.com/Metaswitch/clearwater-snmp-handlers/pull/119) and remove the user/logs on uninstall (part of the fix for #247)

If this is OK, I'll do the same changes to every other repo (woo!)