### PR TITLE
[No reviewer] Replace commas with whitespace

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -83,17 +83,16 @@ create_cluster()
         echo Creating new cluster...
 
         # Build the initial cluster view string based on the IP addresses in
-        # $etcd_cluster.  Each entry looks like <name>=<peer url>.
+        # $etcd_cluster. Each entry looks like <name>=<peer url>. Replace
+        # commas with whitespace, then split on whitespace (to cope with
+        # etcd_cluster values that have spaces)
         ETCD_INITIAL_CLUSTER=
-        OLD_IFS=$IFS
-        IFS=,
-        for server in $etcd_cluster
+        for server in ${etcd_cluster//,/ }
         do
             server_name=${server%:*}
             server_name=${server_name//./-}
             ETCD_INITIAL_CLUSTER="${server_name}=http://$server:2380,$ETCD_INITIAL_CLUSTER"
         done
-        IFS=$OLD_IFS
 
         CLUSTER_ARGS="--initial-cluster $ETCD_INITIAL_CLUSTER
                       --initial-cluster-state new"
@@ -102,18 +101,17 @@ create_cluster()
 setup_etcdctl_peers()
 {
         # Build the client list based on $etcd_cluster, each entry is simply
-        # <IP>:<port> using the client port.
+        # <IP>:<port> using the client port. Replace commas with whitespace,
+        # then split on whitespace (to cope with etcd_cluster values that have
+        # spaces)
         export ETCDCTL_PEERS=
-        OLD_IFS=$IFS
-        IFS=,
-        for server in $etcd_cluster
+        for server in ${etcd_cluster//,/ }
         do
             if [[ $server != $advertisement_ip ]]
             then
                 ETCDCTL_PEERS="$server:4000,$ETCDCTL_PEERS"
             fi
         done
-        IFS=$OLD_IFS
 }
 
 
@@ -130,15 +128,14 @@ join_cluster()
         TEMP_FILE=$(mktemp)
 
         # Build the client list based on $etcd_cluster, each entry is simply
-        # <IP>:<port> using the client port.
+        # <IP>:<port> using the client port. Replace commas with whitespace,
+        # then split on whitespace (to cope with etcd_cluster values that have
+        # spaces)
         export ETCDCTL_PEERS=
-        OLD_IFS=$IFS
-        IFS=,
-        for server in $etcd_cluster
+        for server in ${etcd_cluster//,/ }
         do
             ETCDCTL_PEERS="$server:4000,$ETCDCTL_PEERS"
         done
-        IFS=$OLD_IFS
 
         # Check to make sure the cluster we want to join is healthy.
         # If it's not, don't even try joining (it won't work, and may


### PR DESCRIPTION
Deals with the case where the etcd_cluster variable contains spaces
Fixes #237