### PR TITLE
Be more careful matching IP addresses

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -226,7 +226,7 @@ do_start()
         # <id>[unstarted]: name=xx-xx-xx-xx peerURLs=http://xx.xx.xx.xx:2380 clientURLs=http://xx.xx.xx.xx:4000
         # The [unstarted] is only present while the member hasn't fully joined the etcd cluster
         setup_etcdctl_peers
-        member=$(/usr/bin/etcdctl member list | grep "unstarted" | grep $listen_ip )
+        member=$(/usr/bin/etcdctl member list | grep "unstarted" | grep -F -w $listen_ip )
         if [[ $member != '' ]]
         then
           member_id=$(echo $member | grep -o "^[^[]\+")


### PR DESCRIPTION
For example, don't match 1.2.3.40 when looking for 1.2.3.4.

Check for non-word characters around the IP address.