### PR TITLE
Be careful when grepping for IPs in another place

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -373,7 +373,7 @@ do_decommission()
           return 2
         fi
 
-        id=$(/usr/bin/etcdctl member list | grep ${advertisement_ip//./-} | cut -f 1 -d :)
+        id=$(/usr/bin/etcdctl member list | grep -F -w ${advertisement_ip//./-} | cut -f 1 -d :)
         if [[ -z $id ]]
         then
           echo Local node does not appear in the cluster


### PR DESCRIPTION
There's another place in the same file that might use the word-delimitation fix. `10-67-79-1 != 10-67-79-10`