### PR TITLE
[Reviewer: Matt] Lock etcd's pidfile before we write to it

### DIFF
--- a/clearwater-etcd/usr/bin/etcdwrapper
+++ b/clearwater-etcd/usr/bin/etcdwrapper
@@ -13,7 +13,12 @@ exec 200>$PIDFILE_LOCK
 
 # Exit unless we have an exclusive lock on file handle 200 (the lock file) -
 # i.e. unless no other etcd process is running
-flock --nonblock 200 || exit 99
+if ! flock --nonblock 200
+then
+  existing_pid=$(cat $PIDFILE)
+  echo "Error: could not acquire lock on $PIDFILE_LOCK, pid $existing_pid holds it" >> /var/log/clearwater-etcd/clearwater-etcd.log 2>&1
+  exit 99
+fi
 
 # After this point, we can be sure we're the only script running, so we can
 # write to the pidfile without fear that another etcd process will start

--- a/clearwater-etcd/usr/bin/etcdwrapper
+++ b/clearwater-etcd/usr/bin/etcdwrapper
@@ -1,7 +1,25 @@
 #!/bin/bash
 
-# Tiny wrapper script to redirect etcd's stdout and stderr to a file and raise appropriate ENT logs
+# Wrapper script to redirect etcd's stdout and stderr to a file and raise appropriate ENT logs
+# This also uses flock(1) to ensure that only one etcd process can write the pidfile at once
+# See https://tobrunet.ch/2013/01/follow-up-bash-script-locking-with-flock/ for more on Bash file locking
+
+PIDFILE=/var/run/clearwater-etcd/clearwater-etcd.pid
+PIDFILE_LOCK=/var/run/clearwater-etcd/clearwater-etcd.pid.lock
+
+# Claim file handle 200, writing to the lock file, so we can reference it on
+# the next line
+exec 200>$PIDFILE_LOCK 
+
+# Exit unless we have an exclusive lock on file handle 200 (the lock file) -
+# i.e. unless no other etcd process is running
+flock --nonblock 200 || exit 99
+
+# After this point, we can be sure we're the only script running, so we can
+# write to the pidfile without fear that another etcd process will start
 
 /usr/share/clearwater/bin/ent_log.py "etcd" CL_ETCD_STARTED
+echo $$ > $PIDFILE
 exec /usr/bin/etcd $@ >> /var/log/clearwater-etcd/clearwater-etcd.log 2>&1
+rm $PIDFILE
 /usr/share/clearwater/bin/ent_log.py "etcd" CL_ETCD_EXITED

--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -54,7 +54,7 @@
 DESC="etcd"
 NAME=clearwater-etcd
 DATA_DIR=/var/lib/$NAME
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=/var/run/$NAME/$NAME.pid
 DAEMON=/usr/bin/etcd
 DAEMONWRAPPER=/usr/bin/etcdwrapper
 
@@ -265,6 +265,9 @@ do_start()
           return 2
         fi
 
+        # Allow us to write to the pidfile directory
+        install -m 755 -o $NAME -g root -d /var/run/$NAME && chown -R $NAME /var/run/$NAME
+
         # Common arguments
         DAEMON_ARGS="--listen-client-urls http://$listen_ip:4000
                      --advertise-client-urls http://$advertisement_ip:4000
@@ -299,7 +302,7 @@ do_rebuild()
                      --name $ETCD_NAME
                      --force-new-cluster"
 
-        start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --startas $DAEMONWRAPPER --chuid $NAME -- $DAEMON_ARGS $CLUSTER_ARGS \
+        start-stop-daemon --start --quiet --background --pidfile $PIDFILE --startas $DAEMONWRAPPER --chuid $NAME -- $DAEMON_ARGS $CLUSTER_ARGS \
                 || return 2
 
         wait_for_etcd

--- a/debian/clearwater-etcd.postinst
+++ b/debian/clearwater-etcd.postinst
@@ -88,7 +88,7 @@ case "$1" in
         setup_user
         setup_data_dir
         setup_log_dir
-
+        
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-etcd.monit /etc/monit/conf.d/
         reload clearwater-monit || /bin/true
 
@@ -97,6 +97,11 @@ case "$1" in
         # significant lag.)
         # Don't fail if it's already stopped.
         service clearwater-etcd stop || /bin/true
+        
+        # Clean up any pidfile still in the old location - we've moved it to
+        # /var/run/clearwater-etd/clearwater-etcd.pid
+        rm -f /var/run/$NAME.pid
+
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/clearwater-etcd.prerm
+++ b/debian/clearwater-etcd.prerm
@@ -64,9 +64,6 @@ case "$1" in
         # Make sure the process is stopped
         service clearwater-etcd stop
 
-        # Clean up old pidfile
-        rm -f /var/run/$NAME.pid
-
         # Now do necessary cleanup. Don't remove the
         # user/logs/data dir if we're just upgrading.
         if [ $1 != "upgrade" ]; then

--- a/debian/clearwater-etcd.prerm
+++ b/debian/clearwater-etcd.prerm
@@ -64,6 +64,9 @@ case "$1" in
         # Make sure the process is stopped
         service clearwater-etcd stop
 
+        # Clean up old pidfile
+        rm -f /var/run/$NAME.pid
+
         # Now do necessary cleanup. Don't remove the
         # user/logs/data dir if we're just upgrading.
         if [ $1 != "upgrade" ]; then


### PR DESCRIPTION
Can you review this fix to https://github.com/Metaswitch/clearwater-etcd/issues/262? Essentially, because we don't build etcd ourselves, I've done the pidfile locking stuff we normally do in C/Python code in a Bash wrapper script instead.

As this is Bash magic, you seemed like the best reviewer - shout if you're too busy.