### PR TITLE
[Reviewer: Graeme] Don't pass PID lock to child processes

### DIFF
--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -53,9 +53,12 @@ def run_command(command, namespace=None, log_error=True):
         command = "ip netns exec {} ".format(namespace) + command
 
     try:
+        # Pass the close_fds argument to avoid the pidfile lock being held by
+        # child processes
         output = subprocess.check_output(command,
                                          shell=True,
-                                         stderr=subprocess.STDOUT)
+                                         stderr=subprocess.STDOUT,
+                                         close_fds=True)
         _log.debug("Command {} succeeded and printed output {!r}".
                    format(command, output))
         return 0


### PR DESCRIPTION
Remember that bug we hit where bono quiescing held the clearwater-queue-manager PID lock?

I hit it again, and figured out how to stop spawned processes holding the PID lock.