### PR TITLE
[Reviewer: Ellie] Don't let start-stop-daemon create the pidfile without taking a lock

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -275,7 +275,7 @@ do_start()
                      --name $ETCD_NAME
                      --debug"
 
-        start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --startas $DAEMONWRAPPER --chuid $NAME -- $DAEMON_ARGS $CLUSTER_ARGS \
+        start-stop-daemon --start --quiet --background --pidfile $PIDFILE --startas $DAEMONWRAPPER --chuid $NAME -- $DAEMON_ARGS $CLUSTER_ARGS \
                 || return 2
 
         wait_for_etcd


### PR DESCRIPTION
Fixes #262 - I think for real this time.

I've run the following script:

```
for i in {1..150}
do
  service clearwater-etcd restart &
done
```

which reliably reproduced the issue before this fix and doesn't do so afterwards.

I've also checked that there are no other instances of `--make-pidfile` in the init.d script.