### PR TITLE
Reviewer RKD: Don't trigger TOO_LONG_CLUSTERING alarm if we're not in the cluster

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
+++ b/src/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
@@ -139,7 +139,7 @@ class SyncFSM(object):
         # long" alarm is running, and cancel it if we're not
         if local_state == constants.NORMAL:
             self._alarm.cancel()
-        else:
+        elif self._plugin.should_be_in_cluster():
             self._alarm.trigger(self._id)
 
         # Handle the abnormal cases first - where the local node isn't in the


### PR DESCRIPTION
Fixes #289.

I've tested by spinning up a GR deployment with 2 Ralfs in each site. Without this change, the TOO_LONG_CLUSTERING alarm was raised after 15 minutes on all the nodes. With this change, the alarm wasn't raised.

@JimBunch I'm going to merge into release-94-fixes once this is reviewed - is that ok? I'll leave it up to you whether you want to take a new build with it.