### PR TITLE
Reviewer Ellie - Prevent starting before ready

### DIFF
--- a/debian/clearwater-cluster-manager.init.d
+++ b/debian/clearwater-cluster-manager.init.d
@@ -102,6 +102,8 @@ do_start()
   signaling_namespace=""
   etcd_key=clearwater
   etcd_cluster_key=""
+  log_level=3
+  log_directory=/var/log/clearwater-cluster-manager
   
   # This sets up $uuid - it's created by /usr/share/clearwater/infrastructure/scripts/node_identity
   . /etc/clearwater/node_identity
@@ -111,9 +113,12 @@ do_start()
     . /usr/share/clearwater/node_type.d/$(ls /usr/share/clearwater/node_type.d | head -n 1)
   fi
   . /etc/clearwater/config
-  log_level=3
-  log_directory=/var/log/clearwater-cluster-manager
-  [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
+
+  if [[ -z $local_ip ]]
+  then
+    echo "/etc/clearwater/local_config not provided, not starting"
+    return 3
+  fi
 
   DAEMON_ARGS="--mgmt-local-ip=${management_local_ip:-$local_ip}
                --sig-local-ip=$local_ip

--- a/debian/clearwater-config-manager.init.d
+++ b/debian/clearwater-config-manager.init.d
@@ -91,10 +91,15 @@ do_start()
 
   local_site_name=site1
   etcd_key=clearwater
-  . /etc/clearwater/config
   log_level=3
   log_directory=/var/log/clearwater-config-manager
-  [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
+  . /etc/clearwater/config
+
+  if [[ -z $local_ip ]]
+  then
+    echo "/etc/clearwater/local_config not provided, not starting"
+    return 3
+  fi
 
   DAEMON_ARGS="--local-ip=${management_local_ip:-$local_ip} --local-site=$local_site_name --log-level=$log_level --log-directory=$log_directory --pidfile=$PIDFILE --etcd-key=$etcd_key"
 

--- a/debian/clearwater-queue-manager.init.d
+++ b/debian/clearwater-queue-manager.init.d
@@ -86,14 +86,19 @@ do_start()
   local_site_name=site1
   etcd_key=clearwater
   etcd_cluster_key=unknown
+  log_level=3
+  log_directory=/var/log/clearwater-queue-manager
   if [ -d /usr/share/clearwater/node_type.d ]
   then
     . /usr/share/clearwater/node_type.d/$(ls /usr/share/clearwater/node_type.d | head -n 1)
   fi
   . /etc/clearwater/config
-  log_level=3
-  log_directory=/var/log/clearwater-queue-manager
-  [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
+
+  if [[ -z $local_ip ]]
+  then
+    echo "/etc/clearwater/local_config not provided, not starting"
+    return 3
+  fi
 
   DAEMON_ARGS="--local-ip=${management_local_ip:-$local_ip} --local-site=$local_site_name --log-level=$log_level --log-directory=$log_directory --pidfile=$PIDFILE --etcd-key=$etcd_key --node-type=$etcd_cluster_key"
 


### PR DESCRIPTION
As discussed, most of our processes refuse to start until shared config has been provided.  This brings `clearwater-*-manager` into consistent behaviour (but with local_config rather than shared).

This makes it possible to add config after installing the software (e.g. to make images).