### PR TITLE
[Reviewer: AJH] Fix polling for health when configured as a proxy

### DIFF
--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
@@ -49,7 +49,7 @@ if [ -n "$1" ] && [ $1 == "--quorum" ]; then
   output="\"key\":\"$key\",\"value\":\"True\""
 else
   path="http://${management_local_ip:-$local_ip}:4000/v2/stats/self"
-  if [ ! -z $etcd_cluster ]; then
+  if [ ! -z "$etcd_cluster" ]; then
     # Configured as a master, so we will be in the list of etcd nodes.
     output="\"name\":\"${management_local_ip:-$local_ip}\""
   else

--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
@@ -54,7 +54,7 @@ else
     output="\"name\":\"${management_local_ip:-$local_ip}\""
   else
     # Configured as a proxy, so we won't be in the list of etcd nodes.
-    # Just chck that there is a configured master - we don't really
+    # Just check that there is a configured master - we don't really
     # care about what it's name or address is.
     output="\"name\":\""
   fi

--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd.sh
@@ -49,7 +49,15 @@ if [ -n "$1" ] && [ $1 == "--quorum" ]; then
   output="\"key\":\"$key\",\"value\":\"True\""
 else
   path="http://${management_local_ip:-$local_ip}:4000/v2/stats/self"
-  output="\"name\":\"${management_local_ip:-$local_ip}\""
+  if [ ! -z $etcd_cluster ]; then
+    # Configured as a master, so we will be in the list of etcd nodes.
+    output="\"name\":\"${management_local_ip:-$local_ip}\""
+  else
+    # Configured as a proxy, so we won't be in the list of etcd nodes.
+    # Just chck that there is a configured master - we don't really
+    # care about what it's name or address is.
+    output="\"name\":\""
+  fi
 fi
 
 curl -L $path 2> /tmp/poll-etcd.sh.stderr.$$ | tee /tmp/poll-etcd.sh.stdout.$$ | grep -q $output


### PR DESCRIPTION
When we are a proxy, we won't be listed in /v2/stats/self. We don't actually care what node is listed at this point, we just need one to be.

As such, we change what we look for in the results from `"name":"{local_ip}"` to `"name":"` when we are configured as a proxy (i.e. etcd_cluster is blank).

Without this fix, when configured as a proxy, monit will continually restart etcd.

I've tested this by spinning up a deployment with proxies and verifying they don't get killed, and manually running the script on both master and proxy nodes to ensure it's doing the right thing.