### PR TITLE
[Reviewer: Ellie] Catch socket connection error

### DIFF
--- a/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
+++ b/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
@@ -40,16 +40,19 @@ import logging
 
 _log = logging.getLogger(__name__)
 
+
 class Status:
     OK = 0
     WARN = 1
     CRITICAL = 2
 
+
 def check_status():
     try:
         output = subprocess.check_output(['monit', 'summary'])
     except subprocess.CalledProcessError as e:
-        _log.error("Check_output of Monit summary failed: return code {}, printed output {!r}".format(e.returncode,e.output))
+        _log.error("Check_output of Monit summary failed: return code {},"
+                   " printed output {!r}".format(e.returncode, e.output))
         return Status.CRITICAL
 
     result = Status.OK
@@ -77,6 +80,7 @@ def check_status():
                 result = max(result, Status.WARN)
     _log.debug("Current status is %s" % result)
     return result
+
 
 def run_loop():
     # Seconds after which we return an error

--- a/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
+++ b/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
@@ -39,7 +39,6 @@ from time import sleep
 import logging
 
 _log = logging.getLogger(__name__)
-logfile = r"/tmp/node.log"
 
 class Status:
     OK = 0
@@ -47,12 +46,9 @@ class Status:
     CRITICAL = 2
 
 def check_status():
-
     try:
         output = subprocess.check_output(['monit', 'summary'])
     except subprocess.CalledProcessError, e:
-        with open(logfile, 'a') as log:
-            log.write("Hit CalledProcessError in node health check \n")
         _log.error ("subprocess.check_output hit CalledProcessError, output: %s", e.output)
         return Status.CRITICAL
 
@@ -95,8 +91,6 @@ def run_loop():
 
         if status == Status.CRITICAL:
             success_count = 0
-            with open(logfile, 'a') as log:
-                log.write("checking to make sure we are appending not overwriting \n")
 
         if success_count >= 30:
             return True

--- a/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
+++ b/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
@@ -48,8 +48,8 @@ class Status:
 def check_status():
     try:
         output = subprocess.check_output(['monit', 'summary'])
-    except subprocess.CalledProcessError, e:
-        _log.error ("subprocess.check_output hit CalledProcessError, output: %s", e.output)
+    except subprocess.CalledProcessError as e:
+        _log.error("Check_output of Monit summary failed: return code {}, printed output {!r}".format(e.returncode,e.output))
         return Status.CRITICAL
 
     result = Status.OK

--- a/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
+++ b/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py
@@ -39,6 +39,7 @@ from time import sleep
 import logging
 
 _log = logging.getLogger(__name__)
+logfile = r"/tmp/node.log"
 
 class Status:
     OK = 0
@@ -46,7 +47,14 @@ class Status:
     CRITICAL = 2
 
 def check_status():
-    output = subprocess.check_output(['monit', 'summary'])
+
+    try:
+        output = subprocess.check_output(['monit', 'summary'])
+    except subprocess.CalledProcessError, e:
+        with open(logfile, 'a') as log:
+            log.write("Hit CalledProcessError in node health check \n")
+        _log.error ("subprocess.check_output hit CalledProcessError, output: %s", e.output)
+        return Status.CRITICAL
 
     result = Status.OK
     critical_errors = [
@@ -87,6 +95,8 @@ def run_loop():
 
         if status == Status.CRITICAL:
             success_count = 0
+            with open(logfile, 'a') as log:
+                log.write("checking to make sure we are appending not overwriting \n")
 
         if success_count >= 30:
             return True

--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -54,7 +54,6 @@ def run_command(command, namespace=None, log_error=True):
 
     # Pass the close_fds argument to avoid the pidfile lock being held by
     # child processes
-
     p = subprocess.Popen(command,
                          shell=True,
                          stdout=subprocess.PIPE,
@@ -62,7 +61,7 @@ def run_command(command, namespace=None, log_error=True):
                          close_fds=True)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
-        # it failed, log the return code and output 
+        # it failed, log the return code and output
         _log.error("Command {} failed with return code {}"
                    " and printed output {!r}".format(command,
                                                      p.returncode,
@@ -71,12 +70,13 @@ def run_command(command, namespace=None, log_error=True):
     else:
         # it succeeded, just log out stderr of the command run
         _log.warning("Command {} succeeded, with stderr output {!r}".
-                      format(command, stderr))
+                     format(command, stderr))
         return 0
 
 
 def safely_write(filename, contents, permissions=0644):
-    """Writes a file without race conditions, by writing to a temporary file and then atomically renaming it"""
+    """Writes a file without race conditions, by writing to a temporary file
+    and then atomically renaming it"""
 
     # Create the temporary file in the same directory (to ensure it's on the
     # same filesystem and can be moved atomically), and don't automatically

--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -62,15 +62,21 @@ def run_command(command, namespace=None, log_error=True):
     stdout, stderr = p.communicate()
     if p.returncode != 0:
         # it failed, log the return code and output
-        _log.error("Command {} failed with return code {}"
-                   " and printed output {!r}".format(command,
-                                                     p.returncode,
-                                                     p.output))
-        return p.returncode
+        if log_error:
+            _log.error("Command {} failed with return code {}, "
+                       "stdout {!r}, and stderr {!r}".format(command,
+                                                             p.returncode,
+                                                             stdout,
+                                                             stderr))
+            return p.returncode
     else:
-        # it succeeded, just log out stderr of the command run
-        _log.warning("Command {} succeeded, with stderr output {!r}".
-                     format(command, stderr))
+        # it succeeded, log out stderr of the command run if present
+        if stderr:
+            _log.warning("Command {} succeeded, with stderr output {!r}".
+                         format(command, stderr))
+        else:
+            _log.debug("Command {} succeeded".format(command))
+
         return 0
 
 


### PR DESCRIPTION
The issue seen was that nodes would drop into the failed state in the queue-manager queue very quickly after starting the processing step. 
The telling section of the queue-manager logs stated:
```
21-07-2016 15:50:52.233 UTC ERROR plugin_utils.py:70 (thread ApplyConfigPlugin): Command /usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py failed with return code 1 and printed output 'Cannot create socket to [localhost]:2812 -- Connection refused
```

Looking at the check_node_health script, the subprocess.check_output call can raise a CalledProcessError exception that is only then caught once we have dropped out of the run loop, meaning that a single exception will kick us out of the retry for 450 seconds stage. 

Catching the error in place, and returning that call's status as 'CRITICAL' means that we will perform the run_loop correctly.


This was tested both as below, and also with the additions in the first commit to log to a temporary file, to see how often we hit the exception. 
Running upload shared config to trigger the restart queue, the exception typically appeared on about 1 or two nodes in a 5 node deployment, and was only hit once in each cycle. I.e. we are not seeing multiple attempts and failures to open the socket to localhost:2812. 

This socket is the Monit HTTP interface, which the monitrc file (https://github.com/Metaswitch/clearwater-monit/blob/master/monitrc) says the following on:

```
## Monit has an embedded HTTP interface which can be used to view status of 
## services monitored and manage services from a web interface. The HTTP 
## interface is also required if you want to issue Monit commands from the
## command line, such as 'monit status' or 'monit restart service' The reason
## for this is that the Monit client uses the HTTP interface to send these
## commands to a running Monit daemon. See the Monit Wiki if you want to 
## enable SSL for the HTTP interface. 
#
set httpd port 2812 and
    use address localhost  # only accept connection from localhost
    allow localhost        # allow localhost to connect to the server and
    allow admin:monit      # require user 'admin' with password 'monit'
```

As such, i think that this may be occuring as a side effect of moving up to the newer version of Monit, and it is taking slightly longer than before, or @eleanor-merry has suggested there may be some conflict with the mmonit.monit script. This needs some further investigation, but the fix in this PR should stop the exception pushing a node to the failed state.