### PR TITLE
[Reviewer: Ellie] Pin to setuptools 24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ env: cluster_mgr_setup.py queue_mgr_setup.py config_mgr_setup.py shared_setup.py
 $(ENV_DIR)/bin/python:
 	# Set up the virtual environment
 	virtualenv --setuptools --python=$(PYTHON_BIN) $(ENV_DIR)
-	$(ENV_DIR)/bin/easy_install "setuptools>0.7"
+	$(ENV_DIR)/bin/easy_install "setuptools==24"
 	$(ENV_DIR)/bin/easy_install distribute
 
 include build-infra/cw-deb.mk


### PR DESCRIPTION
Pinning the version of setuptools installed to 24. 
Probably as in https://github.com/Metaswitch/crest/pull/293 , version 25 is causing some issues. 

I was seeing issues when running `make test`, getting the following error output:

```
Installed /tmp/easy_install-wqmOnn/mock-2.0.0/pbr-1.10.0-py2.7.egg
Marker evaluation failed, see the following error.  For more information see: http://docs.openstack.org/developer/pbr/compatibility.html#evaluate-marker
ERROR:root:Error parsing
Traceback (most recent call last):
  File "/tmp/easy_install-wqmOnn/mock-2.0.0/pbr-1.10.0-py2.7.egg/pbr/core.py", line 111, in pbr
    attrs = util.cfg_to_args(path, dist.script_args)
  File "/tmp/easy_install-wqmOnn/mock-2.0.0/pbr-1.10.0-py2.7.egg/pbr/util.py", line 248, in cfg_to_args
    kwargs = setup_cfg_to_setup_kwargs(config, script_args)
  File "/tmp/easy_install-wqmOnn/mock-2.0.0/pbr-1.10.0-py2.7.egg/pbr/util.py", line 431, in setup_cfg_to_setup_kwargs
    if pkg_resources.evaluate_marker('(%s)' % env_marker):
  File "/home/ubuntu/clearwater-etcd/_env/local/lib/python2.7/site-packages/pkg_resources.py", line 1231, in evaluate_marker
    return cls.interpret(parser.expr(text).totuple(1)[1])
  File "/home/ubuntu/clearwater-etcd/_env/local/lib/python2.7/site-packages/pkg_resources.py", line 1266, in interpret
    return op(nodelist)
  File "/home/ubuntu/clearwater-etcd/_env/local/lib/python2.7/site-packages/pkg_resources.py", line 1183, in atom
    return cls.interpret(nodelist[2])
  File "/home/ubuntu/clearwater-etcd/_env/local/lib/python2.7/site-packages/pkg_resources.py", line 1266, in interpret
    return op(nodelist)
  File "/home/ubuntu/clearwater-etcd/_env/local/lib/python2.7/site-packages/pkg_resources.py", line 1201, in comparison
    raise SyntaxError(repr(cop)+" operator not allowed in environment markers")
SyntaxError: '<' operator not allowed in environment markers
Coverage.py warning: No data was collected.
error: Setup script exited with error in setup command: Error parsing /tmp/easy_install-wqmOnn/mock-2.0.0/setup.cfg: SyntaxError: '<' operator not allowed in environment markers
make: *** [coverage] Error 1
```

The build server only appears to be picking up version 18, depite the fact that it should be running a make clean. 

Is it worth logging this for investigation somewhere?