### PR TITLE
[Reviewer: Matt] Use etcd-dump-logs to detect and recover from data dir corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ Joining an existing cluster requires determining the list of nodes that are curr
 ### Decommissioning
 
 To decommission a node run `sudo service clearwater-etcd decommission` which will gracefully remove the local node, stop the local `etcd` service and destroy the node's state.  At this point, the `etcd` service can be re-attached to that (or another) `etcd` cluster by updating `etcd_cluster` and starting the `clearwater-etcd` service.
+
+## etcd sources
+
+* `etcd` and `etcdctl` are the versions downloaded from <https://github.com/coreos/etcd/releases/download/v2.2.5/etcd-v2.2.5-linux-amd64.tar.gz>
+* `etcd-dump-logs` is built from <https://github.com/coreos/etcd/blob/v2.2.5/tools/etcd-dump-logs/main.go>


### PR DESCRIPTION
This fixes #293 - see my notes in that issue, particularly https://github.com/Metaswitch/clearwater-etcd/issues/293#issuecomment-244342613, for more information.

I'm planning to test by:

* just spinning up a normal deployment and checking that it works
* forcing a node into 'unstarted' state (probably by commenting out https://github.com/Metaswitch/clearwater-etcd/blob/dev/debian/clearwater-etcd.init.d#L304 so that 'member add' runs but etcd doesn't start) and checking that the code to recover from that state hasn't broken due to my refactoring of it
* uploading the two broken etcd data directories you captured as part of #293 to a node, starting etcd, and confirming that it deletes the data directories and rejoins the cluster in both cases