### PR TITLE
Reviewer EM: Catch exceptions in plugins

### DIFF
--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -129,7 +129,7 @@ def main(args):
 
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, alarm, etcd_key)
-        thread = Thread(target=syncer.main, name=plugin.__class__.__name__)
+        thread = Thread(target=syncer.main_wrapper, name=plugin.__class__.__name__)
         thread.start()
 
         threads.append(thread)

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -129,10 +129,9 @@ def main(args):
 
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, alarm, etcd_key)
-        thread = Thread(target=syncer.main_wrapper, name=plugin.__class__.__name__)
-        thread.start()
+        syncer.start_thread()
 
-        threads.append(thread)
+        threads.append(syncer.thread)
         _log.info("Loaded plugin %s" % plugin)
 
     while any([thr.isAlive() for thr in threads]):

--- a/src/metaswitch/clearwater/config_manager/test/test_basic.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_basic.py
@@ -51,7 +51,7 @@ class BasicTest(unittest.TestCase):
         # Write some initial data into the key
         e._client.write("/clearwater/local/configuration/test", "initial data")
 
-        thread = Thread(target=e.main)
+        thread = Thread(target=e.main_wrapper)
         thread.daemon=True
         thread.start()
 

--- a/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
@@ -57,6 +57,9 @@ import etcd
 from threading import Thread
 from time import sleep
 import logging
+import traceback
+import os
+import signal
 
 _log = logging.getLogger(__name__)
 
@@ -137,7 +140,7 @@ class CommonEtcdSynchronizer(object):
         # threads controlled by a futures is shut down fully
         self._terminate_flag = False
         self._abort_read = False
-        self.thread = Thread(target=self.main, name=self.thread_name())
+        self.thread = Thread(target=self.main_wrapper, name=self.thread_name())
 
     def start_thread(self):
         self.thread.daemon = True
@@ -149,6 +152,17 @@ class CommonEtcdSynchronizer(object):
 
     def pause(self):
         sleep(self.PAUSE_BEFORE_RETRY_ON_EXCEPTION)
+
+    def main_wrapper(self): # pragma: no cover
+        # This function should be the entry point when we start an
+        # EtcdSynchronizer thread. We use it to catch exceptions in main and
+        # restart the whole process; if we didn't do this the thread would be
+        # dead and we'd never notice.
+        try:
+            self.main()
+        except Exception:
+            _log.error(traceback.format_exc())
+            os.kill(os.getpid(), signal.SIGTERM)
 
     def main(self): pass
 

--- a/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
@@ -161,6 +161,9 @@ class CommonEtcdSynchronizer(object):
         try:
             self.main()
         except Exception:
+            # Log the exception and send a SIGTERM to this process. If the
+            # process needs to do anything before shutting down, it will have a
+            # handler for catching the SIGTERM.
             _log.error(traceback.format_exc())
             os.kill(os.getpid(), signal.SIGTERM)
 

--- a/src/metaswitch/clearwater/queue_manager/main.py
+++ b/src/metaswitch/clearwater/queue_manager/main.py
@@ -125,7 +125,7 @@ def main(args):
 
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, etcd_key, node_type)
-        thread = Thread(target=syncer.main, name=plugin.__class__.__name__)
+        thread = Thread(target=syncer.main_wrapper, name=plugin.__class__.__name__)
         thread.start()
 
         threads.append(thread)

--- a/src/metaswitch/clearwater/queue_manager/main.py
+++ b/src/metaswitch/clearwater/queue_manager/main.py
@@ -125,10 +125,9 @@ def main(args):
 
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, etcd_key, node_type)
-        thread = Thread(target=syncer.main_wrapper, name=plugin.__class__.__name__)
-        thread.start()
+        syncer.start_thread()
 
-        threads.append(thread)
+        threads.append(syncer.thread)
         _log.info("Loaded plugin %s" % plugin)
 
     while any([thr.isAlive() for thr in threads]):

--- a/src/metaswitch/clearwater/queue_manager/test/test_base.py
+++ b/src/metaswitch/clearwater/queue_manager/test/test_base.py
@@ -44,7 +44,7 @@ class BaseQueueTest(unittest.TestCase):
     def set_initial_val(self, queue_config):
         # Write some initial data into the key and start the synchronizer
         self._e._client.write("/clearwater/local/configuration/queue_test", queue_config)
-        thread = Thread(target=self._e.main)
+        thread = Thread(target=self._e.main_wrapper)
         thread.daemon=True
         thread.start()
 


### PR DESCRIPTION
Fixes #317 by wrapping the plugin thread entry point in a try/except branch.

I did the following testing...
* I added a line in `on_config_changed` in `shared_config_plugin.py` to always raise an IOError on Sprout-1.
* I changed `shared_config` on one of my nodes and the exception was raised. Details of the exception were logged to `config-manager.output.log`. The `clearwater-config-manager` process continued to run. Next time I changed `shared_config` nothing happened because the shared config plugin thread was dead.
* I upgraded Sprout-1 to include my fix. Now when the process was restarted the exception was caught, a nice stack trace was printed in the normal config file, and the process was killed. (Monit then restarted the process and it happened again because I was still raising the same IOError).