### PR TITLE
[Reviewer: Ellie] Add etcd scripts for N-site GR upgrade

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+set -ue
+
+local_site_name=site1
+
+. /etc/clearwater/config
+
+if [ $# -ne 3 ]
+then
+  echo "Usage: recreate_cluster [old_node_type] [new_node_type] [storage_type]"
+  exit 1
+fi
+
+old_node_type=$1
+new_node_type=$2
+storage_type=$3
+
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py "$old_node_type" "$new_node_type" "$storage_type"
+

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py
@@ -48,27 +48,31 @@ new_node_type = sys.argv[2]
 storage_type = sys.argv[3]
 
 print("Copying cluster information for {0} on {1} to {2}".format(storage_type,
-    old_node_type, new_node_type))
+                                                                 old_node_type,
+                                                                 new_node_type))
 
-# List all keys stored in etcd
-# -p appends a "/" to all directories to help distinguish them from keys
-process = subprocess.Popen("clearwater-etcdctl ls -p --recursive", stdout=subprocess.PIPE, shell=True)
+try:
+    # List all keys stored in etcd
+    # -p appends a "/" to all directories to help distinguish them from keys
+    output_str = subprocess.check_output(["clearwater-etcdctl", "ls", "-p", "--recursive"])
+    new_data = {}
 
-new_data = {}
+    for line in output_str.splitlines():
+        line = line.strip()
 
-for line in process.stdout:
+        # Only need to rename keys containing the old node name for this storage type
+        if (line.endswith("/{0}".format(storage_type))) and ("/{0}/".format(old_node_type) in line):
+            value = get_value(line)
+            new_key = line.replace("/{0}/".format(old_node_type), "/{0}/".format(new_node_type))
+            new_data[new_key] = value
 
-    line = line.strip()
+    # Add the new key-value pairs
+    for key, value in new_data.iteritems():
+        subprocess.check_output(["clearwater-etcdctl", "set", key, value])
 
-    # Only need to rename keys containing the old node name for this storage type
-    if (line.endswith("/{0}".format(storage_type))) and ("/{0}/".format(old_node_type) in line):
-        value = get_value(line)
-        new_key = line.replace("/{0}/".format(old_node_type), "/{0}/".format(new_node_type))
-        new_data[new_key] = value
+    print("Done")
 
-# Add the new key-value pairs
-for key, value in new_data.iteritems():
-    subprocess.check_output(["clearwater-etcdctl", "set", key, value])
-
-print("Done")
+except subprocess.CalledProcessError, e:
+    print("ERROR: Unable to contact etcd.")
+    print("ERROR: Confirm etcd is running and try again.")
 

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py
@@ -1,0 +1,74 @@
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import json
+import subprocess
+import sys
+
+
+# Gets the value from etcd for the given key
+def get_value(key):
+    stored_value = subprocess.check_output(["clearwater-etcdctl", "get", key])
+    return stored_value.strip()
+
+
+# Start
+
+old_node_type = sys.argv[1]
+new_node_type = sys.argv[2]
+storage_type = sys.argv[3]
+
+print("Copying cluster information for {0} on {1} to {2}".format(storage_type,
+    old_node_type, new_node_type))
+
+# List all keys stored in etcd
+# -p appends a "/" to all directories to help distinguish them from keys
+process = subprocess.Popen("clearwater-etcdctl ls -p --recursive", stdout=subprocess.PIPE, shell=True)
+
+new_data = {}
+
+for line in process.stdout:
+
+    line = line.strip()
+
+    # Only need to rename keys containing the old node name for this storage type
+    if (line.endswith("/{0}".format(storage_type))) and ("/{0}/".format(old_node_type) in line):
+        value = get_value(line)
+        new_key = line.replace("/{0}/".format(old_node_type), "/{0}/".format(new_node_type))
+        new_data[new_key] = value
+
+# Add the new key-value pairs
+for key, value in new_data.iteritems():
+    subprocess.check_output(["clearwater-etcdctl", "set", key, value])
+
+print("Done")
+

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_homestead_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_homestead_cluster
@@ -34,19 +34,15 @@
 
 set -ue
 
-local_site_name=site1
-
 . /etc/clearwater/config
 
-if [ $# -ne 3 ]
+# Check we can contact `etcd`
+if ! nc -z ${management_local_ip:-$local_ip} 4000
 then
-  echo "Usage: recreate_cluster [old_node_type] [new_node_type] [storage_type]"
+  echo "The Clearwater Configuration store (etcd) is not running"
+  echo "Please start it before uploading configuration"
   exit 1
 fi
 
-old_node_type=$1
-new_node_type=$2
-storage_type=$3
-
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py "$old_node_type" "$new_node_type" "$storage_type"
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py homestead vellum cassandra
 

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_homestead_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_homestead_cluster
@@ -40,7 +40,7 @@ set -ue
 if ! nc -z ${management_local_ip:-$local_ip} 4000
 then
   echo "The Clearwater Configuration store (etcd) is not running"
-  echo "Please start it before uploading configuration"
+  echo "Start it and then try again"
   exit 1
 fi
 

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_sprout_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_sprout_cluster
@@ -40,7 +40,7 @@ set -ue
 if ! nc -z ${management_local_ip:-$local_ip} 4000
 then
   echo "The Clearwater Configuration store (etcd) is not running"
-  echo "Please start it before uploading configuration"
+  echo "Start it and then try again"
   exit 1
 fi
 

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_sprout_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_sprout_cluster
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2016 Metaswitch Networks Ltd
 #
@@ -30,23 +32,21 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-import json
-import subprocess
-import sys
+set -ue
 
-filename = sys.argv[1]
+. /etc/clearwater/config
 
-print("Loading etcd cluster info from {0}\n".format(filename))
+# Check we can contact `etcd`
+if ! nc -z ${management_local_ip:-$local_ip} 4000
+then
+  echo "The Clearwater Configuration store (etcd) is not running"
+  echo "Please start it before uploading configuration"
+  exit 1
+fi
 
-data = {}
+# Run the recreate_cluster.py script twice, once for each of Chronos and Memcached
 
-# Load saved data from the temp file
-with open(filename, "r") as loaded_file:
-    data = json.load(loaded_file)
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py sprout vellum memcached
 
-# Add to etcd
-for key, value in data.iteritems():
-    subprocess.check_output(["clearwater-etcdctl", "set", key, value])
-
-print("Loaded etcd cluster info from disk")
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/recreate_cluster.py sprout vellum chronos
 

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config
@@ -34,4 +34,22 @@
 
 set -ue
 
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config.py
+if [ $# -ne 1 ]
+then
+  echo "Usage: load_etcd_config [filename]"
+  exit 1
+fi
+
+. /etc/clearwater/config
+
+# Check we can contact `etcd`
+if ! nc -z ${management_local_ip:-$local_ip} 4000
+then
+  echo "The Clearwater Configuration store (etcd) is not running"
+  echo "Please start it before uploading configuration"
+  exit 2
+fi
+
+filename=$1
+
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config.py "$filename"

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config
@@ -46,7 +46,7 @@ fi
 if ! nc -z ${management_local_ip:-$local_ip} 4000
 then
   echo "The Clearwater Configuration store (etcd) is not running"
-  echo "Please start it before uploading configuration"
+  echo "Start it and then try again"
   exit 2
 fi
 

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+set -ue
+
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config.py

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config.py
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/load_etcd_config.py
@@ -1,0 +1,52 @@
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import json
+import subprocess
+
+
+# Start
+
+print("Loading etcd cluster info from disk...")
+
+data = {}
+
+# Load saved data from the temp file
+with open("/tmp/saved_etcd_config", "r") as loaded_file:
+    data = json.load(loaded_file)
+
+# Add to etcd
+for key, value in data.iteritems():
+    subprocess.check_output(["clearwater-etcdctl", "set", key, value])
+
+print("\nLoaded etcd cluster info from disk")
+

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config
@@ -42,9 +42,9 @@ local_site_name=site1
 if ! nc -z ${management_local_ip:-$local_ip} 4000
 then
   echo "The Clearwater Configuration store (etcd) is not running"
-  echo "Please start it before uploading configuration"
+  echo "Start it and then try again"
   exit 2
 fi
 
-/usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py "$local_site_name"
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py "$local_site_name"
 

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config
@@ -38,5 +38,13 @@ local_site_name=site1
 
 . /etc/clearwater/config
 
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py "$local_site_name"
+# Check we can contact `etcd`
+if ! nc -z ${management_local_ip:-$local_ip} 4000
+then
+  echo "The Clearwater Configuration store (etcd) is not running"
+  echo "Please start it before uploading configuration"
+  exit 2
+fi
+
+/usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py "$local_site_name"
 

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+set -ue
+
+local_site_name=site1
+
+. /etc/clearwater/config
+
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py "$local_site_name"
+

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py
@@ -52,7 +52,9 @@ def save_to_disk(data, filename):
 # Produces a dictionary like {"[node_ip]": "normal"} containing every cassandra
 # node in the local site
 def get_local_cassandra_nodes(site_name):
-    nodetool_process = subprocess.Popen("nodetool status", stdout=subprocess.PIPE, shell=True)
+    nodetool_process = subprocess.Popen("/usr/share/clearwater/bin/run-in-signaling-namespace nodetool status",
+                                        stdout=subprocess.PIPE,
+                                        shell=True)
     nodes = {}
 
     # regex which matches from the beginning of the string, expecting U or D,
@@ -73,7 +75,6 @@ def get_local_cassandra_nodes(site_name):
             # indicating that the following nodes are part of the local site
             if "Datacenter: {0}".format(site_name) in line:
                 found_local_section = True
-
         else:
             # Now, loop until we hit the next Datacenter line, looking for nodes
             if "Datacenter: " in line:

--- a/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py
+++ b/clearwater-etcd/usr/share/clearwater/clearwater-etcd/scripts/save_etcd_config.py
@@ -1,0 +1,121 @@
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import json
+import re
+import subprocess
+import sys
+
+
+# Gets the value from etcd for the given key
+def get_value(key):
+    stored_value = subprocess.check_output(["clearwater-etcdctl", "get", key])
+    return stored_value.strip()
+
+
+# Save the config
+def save_to_disk(data):
+    with open("/tmp/saved_etcd_config", "w+") as saved_config_file:
+        json.dump(data, saved_config_file)
+
+
+# Produces a dictionary like {"[node_ip]": "normal"} containing every cassandra
+# node in the local site
+def get_local_cassandra_nodes(site_name):
+    nodetool_process = subprocess.Popen("nodetool status", stdout=subprocess.PIPE, shell=True)
+    nodes = {}
+
+    # regex which matches from the beginning of the string, expecting U or D,
+    # then N, L, J or M, then captures the next word (between whitespace)
+    # This is the IP address of the node, e.g.:
+    #
+    # UN  10.0.144.102  79.67 KB   256     100.0%            090e6728-d592-4c75-b38d-7c25683bc133  RAC1
+    regex = "[U|D][N|L|J|M]\s*([^\s]+)"
+
+    found_local_section = False
+
+    for line in nodetool_process.stdout:
+        # Remove trailing whitespace
+        line = line.strip()
+
+        if not found_local_section:
+            # Loop through until we find the Datacenter: [local_site_name] line
+            # indicating that the following nodes are part of the local site
+            if "Datacenter: {0}".format(site_name) in line:
+                found_local_section = True
+
+        else:
+            # Now, loop until we hit the next Datacenter line, looking for nodes
+            if "Datacenter: " in line:
+                break
+
+            m = re.match(regex, line)
+            if m:
+                nodes[m.group(1)] = "normal"
+
+    return nodes
+
+
+# Start
+
+local_site_name = sys.argv[1]
+
+print("Saving etcd cluster info to disk...")
+
+# List all keys stored in etcd
+# -p appends a "/" to all directories to help distinguish them from keys
+process = subprocess.Popen("clearwater-etcdctl ls -p --recursive", stdout=subprocess.PIPE, shell=True)
+
+# Dictionary that will contain all the key-value pairs that we want to save
+data_to_save = {}
+
+# First, save all keys that contain the local site name
+for line in process.stdout:
+
+    line = line.strip()
+
+    # Save any keys that contain the local site name
+    if (not line.endswith("/")) and ("/{0}/".format(local_site_name) in line):
+
+        value = get_value(line)
+        data_to_save[line] = value
+
+# Now we need to add the homestead cassandra clustering info, but we only
+# want to add the nodes for the local site, so we build this manually
+nodes = get_local_cassandra_nodes(local_site_name)
+data_to_save["/clearwater/vellum/clustering/cassandra"] = json.dumps(nodes)
+
+# Now save the dictionary of keys we want to preserve
+save_to_disk(data_to_save)
+
+print("\nSaved etcd cluster info to disk")
+


### PR DESCRIPTION
The scripts needed for the N-Site GR upgrade.

We only need 3, because the existing load_from_*_cluster scripts should work fine for populating etcd with the cluster info after merging Sprout and Ralf Chronos/memcached clusters

Testing done: manual testing that the correct etcd config is copied/saved/loaded