### PR TITLE
[Reviewer: Adam] Remove parameters from tests

### DIFF
--- a/src/metaswitch/clearwater/plugin_tests/test_apply_config_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_apply_config_plugin.py
@@ -64,19 +64,8 @@ class TestApplyConfigPlugin(unittest.TestCase):
     def test_front_of_queue(self, mock_os_listdir, mock_os_path_exists, mock_run_command):
         """Test Queue Manager front_of_queue function"""
 
-        # Setup Plugin parameters
-        Params = ('10.0.0.1',  # ip
-                  '10.0.1.1',  # mgmt_ip
-                  'local_site',  # local_site
-                  'remote_site',  # remote_site
-                  '',  # remote_cassandra_seeds
-                  '',  # signaling_namespace
-                  uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),  # uuid
-                  'etcd_key',  # etcd_key
-                  'etcd_cluster_key')  # etcd_cluster_key
-
         # Create the plugin
-        plugin = ApplyConfigPlugin(Params)
+        plugin = ApplyConfigPlugin(None)
 
         # Set up the mock environment and expectations
         mock_os_path_exists.return_value = True
@@ -108,19 +97,8 @@ class TestApplyConfigPlugin(unittest.TestCase):
                                              mock_os_path_exists, mock_run_command):
         """Test Queue Manager when check_node_health fails"""
 
-        # Setup Plugin parameters
-        Params = ('10.0.0.1',  # ip
-                  '10.0.1.1',  # mgmt_ip
-                  'local_site',  # local_site
-                  'remote_site',  # remote_site
-                  '',  # remote_cassandra_seeds
-                  '',  # signaling_namespace
-                  uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),  # uuid
-                  'etcd_key',  # etcd_key
-                  'etcd_cluster_key')  # etcd_cluster_key
-
         # Create the plugin
-        plugin = ApplyConfigPlugin(Params)
+        plugin = ApplyConfigPlugin(None)
 
         # Set up the mock environment and expectations
         mock_os_path_exists.return_value = True

--- a/src/metaswitch/clearwater/plugin_tests/test_shared_config_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_shared_config_plugin.py
@@ -48,19 +48,8 @@ class TestSharedConfigPlugin(unittest.TestCase):
     def test_config_changed(self, mock_run_command, mock_safely_write):
         """Test Config Manager writes new config when config has changed"""
 
-        # Setup Plugin parameters
-        Params = ('10.0.0.1',  # ip
-                  '10.0.1.1',  # mgmt_ip
-                  'local_site',  # local_site
-                  'remote_site',  # remote_site
-                  '',  # remote_cassandra_seeds
-                  '',  # signaling_namespace
-                  uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),  # uuid
-                  'etcd_key',  # etcd_key
-                  'etcd_cluster_key')  # etcd_cluster_key
-
         # Create the plugin
-        plugin = SharedConfigPlugin(Params)
+        plugin = SharedConfigPlugin(None)
 
         # Set up the config strings to be tested
         old_config_string = "Test config string here. \n More test config string."
@@ -83,19 +72,8 @@ class TestSharedConfigPlugin(unittest.TestCase):
     def test_config_not_changed(self, mock_run_command, mock_safely_write):
         """Test Config Manager does nothing if called with identical config"""
 
-        # Setup Plugin parameters
-        Params = ('10.0.0.1',  # ip
-                  '10.0.1.1',  # mgmt_ip
-                  'local_site',  # local_site
-                  'remote_site',  # remote_site
-                  '',  # remote_cassandra_seeds
-                  '',  # signaling_namespace
-                  uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),  # uuid
-                  'etcd_key',  # etcd_key
-                  'etcd_cluster_key')  # etcd_cluster_key
-
         # Create the plugin
-        plugin = SharedConfigPlugin(Params)
+        plugin = SharedConfigPlugin(None)
 
         # Set up the config strings to be tested
         old_config_string = "This is more test config. \n It won't change."


### PR DESCRIPTION
The Queue/Config manager plugins aren't created with parameters when they're used, so don't create them with parameters in the UTs