### PR TITLE
[Reviewer Ellie] Allow clients to connect over localhost

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -321,7 +321,7 @@ do_start()
         install -m 755 -o $NAME -g root -d /var/run/$NAME && chown -R $NAME /var/run/$NAME
 
         # Common arguments
-        DAEMON_ARGS="--listen-client-urls http://$listen_ip:4000
+        DAEMON_ARGS="--listen-client-urls http://0.0.0.0:4000
                      --advertise-client-urls http://$advertisement_ip:4000
                      --data-dir $DATA_DIR/$advertisement_ip
                      --name $ETCD_NAME
@@ -348,7 +348,7 @@ do_rebuild()
         create_cluster
 
         # Standard ports
-        DAEMON_ARGS="--listen-client-urls http://$listen_ip:4000
+        DAEMON_ARGS="--listen-client-urls http://0.0.0.0:4000
                      --advertise-client-urls http://$advertisement_ip:4000
                      --listen-peer-urls http://$listen_ip:2380
                      --initial-advertise-peer-urls http://$advertisement_ip:2380


### PR DESCRIPTION
This means we can modify shared_config without needed to know the local IP address.

I've not changed `advertise_peers` since that is used by other `etcd`s to reach this one (so `0.0,0,0` would be a __bad__ idea :grin:).