### PR TITLE
[Reviewer AJH] Don't explicitly stop etcd daemon after local member removed

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -437,16 +437,15 @@ do_decommission()
           return 2
         fi
 
+        # etcdctl will stop the daemon automatically once it has removed the
+        # local id (see https://coreos.com/etcd/docs/latest/runtime-configuration.html
+        # "Remove a Member")
         /usr/bin/etcdctl member remove $id
         if [[ $? != 0 ]]
         then
           echo Failed to remove instance from cluster
           return 2
         fi
-
-        start-stop-daemon --stop --retry=USR2/60/KILL/5 --pidfile $PIDFILE --startas $DAEMONWRAPPER
-        RETVAL=$?
-        [[ $RETVAL == 2 ]] && return 2
 
         rm -f $PIDFILE
 


### PR DESCRIPTION
This takes the explicit "stop daemon" call out of the do_decommission method in /etc/init.d/clearwater-etcd.  The reasoning here is that the preceding etcdctl member remove will do this for us, and doing the explicit duplicate stop occasionally leads to spurious "can't stop daemon" errors that potentially confuse users (and might persuade them that the decommission has failed when it hasn't).

Tested on each of ralf, homestead and sprout nodes, in each case verifying that the clearwater-etcd daemon had stopped after the decommission.