### PR TITLE
[Reviewer: Ellie] Pin urllib3 to 1.17 to prevent build failure

### DIFF
--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.cluster_manager.test',
-    install_requires=["docopt", "pyzmq==15.2", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared", "py2-ipaddress==3.4.1"],
+    install_requires=["docopt", "pyzmq==15.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared", "py2-ipaddress==3.4.1"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.config_manager.test',
-    install_requires=["docopt", "pyzmq==15.2", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt", "pyzmq==15.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/fvtest_setup.py
+++ b/fvtest_setup.py
@@ -42,5 +42,5 @@ setup(
     name='clearwater-etcd-tests',
     version='1.0',
     test_suite='metaswitch.clearwater.etcd_tests',
-    tests_require=['python-etcd'],
+    tests_require=["urllib3==1.17", "python-etcd"],
     )

--- a/queue_mgr_setup.py
+++ b/queue_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.queue_manager.test',
-    install_requires=["docopt", "python-etcd==0.4.3", "pyzmq==15.2", "futures==3.0.5", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==15.2", "futures==3.0.5", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/shared_setup.py
+++ b/shared_setup.py
@@ -46,6 +46,6 @@ setup(
     package_data={
         '': ['*.eml'],
         },
-    install_requires=["docopt", "python-etcd==0.4.3", "pyzmq==15.2", "pyyaml==3.11"],
+    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==15.2", "pyyaml==3.11"],
     tests_require=["Mock"],
     )


### PR DESCRIPTION
python-etcd requires urllib3 > 1.7. If we pull urllib3 1.18.1, the build fails due to https://github.com/shazow/urllib3/issues/986.

To avoid this, and future issues, pin urlib3 1.17 which is known to work.