### PR TITLE
[Reviewer: Graeme] Catch more exceptions

### DIFF
--- a/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
+++ b/clearwater-etcd/usr/share/clearwater/bin/get_etcd_initial_cluster.py
@@ -36,6 +36,7 @@ import httplib
 import json
 import sys
 import uuid
+import socket
 
 def main(ip, servers):
     my_url = "http://{}:2380".format(ip)
@@ -52,7 +53,7 @@ def main(ip, servers):
             cluster = ",".join(members)
             print "{}".format(cluster)
             return
-        except OSError:
+        except (OSError, socket.error):
             pass
 
 if __name__ == "__main__":


### PR DESCRIPTION
When we try and join the etcd cluster (not as a founding member), we query the subset of nodes in the etcd_cluster parameter to get the full list of nodes in the etcd cluster. If the first entry fails because etcd is down, then this throws a socket error which we weren't catching. This then meant that we tried to start etcd with the parameters `--initial-cluster "" --initial-cluster-state existing`, which etcd then barfed on.

Fixes #346 