### PR TITLE
[Reviewer: AJL] Fix 'make verify'

### DIFF
--- a/src/metaswitch/clearwater/plugin_tests/test_cassandra_failed_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_cassandra_failed_plugin.py
@@ -39,9 +39,6 @@ import logging
 _log = logging.getLogger()
 
 from clearwater_etcd_plugins.clearwater_cassandra.cassandra_failed_plugin import CassandraFailedPlugin
-from metaswitch.clearwater.cluster_manager.plugin_base import PluginParams
-from metaswitch.clearwater.cluster_manager import alarm_constants
-from metaswitch.clearwater.cluster_manager.plugin_utils import WARNING_HEADER
 
 class TestCassandraFailedPlugin(unittest.TestCase):
     # run_command returns 0 if a command completes successfully, but python mocks

--- a/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
@@ -112,6 +112,8 @@ seed_provider:\n\
         with mock.patch('clearwater_etcd_plugins.clearwater_cassandra.cassandra_plugin.open', mock.mock_open(read_data=yaml_template), create=True) as mock_open:
             plugin.on_startup(cluster_view)
 
+        mock_open.assert_called_once_with(plugin.files(), "r")
+
         # Set expected calls for the mock commands
         path_exists_call_list = \
             [mock.call("/etc/clearwater/force_cassandra_yaml_refresh"),
@@ -222,6 +224,8 @@ seed_provider:\n\
         with mock.patch('clearwater_etcd_plugins.clearwater_cassandra.cassandra_plugin.open', mock.mock_open(read_data=yaml_template), create=True) as mock_open:
             plugin.on_joining_cluster(cluster_view)
 
+        mock_open.assert_called_once_with(plugin.files(), "r")
+
         # Check the additional calls that we should make when destructive_restart = True actually happen,
         # and that we run the cassandra schema at the end
         run_command_call_list = \
@@ -299,6 +303,8 @@ seed_provider:\n\
         with mock.patch('clearwater_etcd_plugins.clearwater_cassandra.cassandra_plugin.open',
                         mock.mock_open(read_data=yaml_template), create=True) as mock_open:
             plugin.on_leaving_cluster(cluster_view)
+
+        mock_open.assert_called_once_with(plugin.files(), "r")
 
         mock_get_alarm.assert_called_with('cluster-manager',
                                           alarm_constants.CASSANDRA_NOT_YET_DECOMMISSIONED)


### PR DESCRIPTION
Add `mock_open.assert_called_once_with(plugin.files(), "r")` as in the other tests e.g. https://github.com/Metaswitch/clearwater-etcd/blob/dev/src/metaswitch/clearwater/plugin_tests/test_shared_config_plugin.py#L63

so that `make verify` passes.