### PR TITLE
[Reviewer EM] Add /usr/bin links to commonly used scripts

### DIFF
--- a/debian/clearwater-cluster-manager.links
+++ b/debian/clearwater-cluster-manager.links
@@ -1,0 +1,2 @@
+/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state /usr/bin/cw-check_cluster_state
+/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed /usr/bin/cw-mark_node_failed

--- a/debian/clearwater-config-manager.links
+++ b/debian/clearwater-config-manager.links
@@ -1,0 +1,2 @@
+/usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync /usr/bin/cw-check_config_sync
+/usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config /usr/bin/cw-upload_shared_config

--- a/debian/clearwater-queue-manager.links
+++ b/debian/clearwater-queue-manager.links
@@ -1,0 +1,1 @@
+/usr/share/clearwater/clearwater-queue-manager/scripts/check_restart_queue_state /usr/bin/cw-check_restart_queue_state


### PR DESCRIPTION
This PR links puts commonly used Clearwater erscripts in the path in order to remove the need for long paths to be entered every time they're run: its often hard to remember where some of these regularly used scripts live, and tedious to type the full out every time when you do.

AJH recommended the approach of linking scripts explicitly from /usr/bin, rather than explicitly changing the path, as the latter is an "unfriendly" approach to the problem (path changes in packages are generally deprecated) and explicit links give us more control over scripts that users should run as opposed to internal scripts/executables that are not formally part of the user interface.  We agreed that I should add "cw-" to the front of the script names to minimise the chance of clashing with 3rd party packages that happen to be using the same name for their scripts, and that the "cw-" should go on the link only, as many of these scripts will be called from various places in the CC codebase and possibly by 3rd party systems that have been integrated with Clearwater, and any change to the names of the scripts themselves is likely to be highly disruptive.

I'll link the other PRs in this series shortly

Couple of questions

- I've only changed those scripts I am aware of being exposed to a typical Ops team.  Please let me know if there are any others than need the same treatment
- The fact that scripts will now be documented with their "cw-" prefix means that they won't match "Usage" statements (that will still use the old non-prefixed names). Having said that, the usage statements in the ellis tools don't match anyway as they say, e.g. "Usage: create_user**.py**".  Is htis going to be a problem?