### PR TITLE
[Reviewer EM] Call validation checking scripts before uploading shared config

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config
@@ -69,6 +69,43 @@ then
   exit 2
 fi
 
+# Run any config validation scripts (either native or supplied by an integrator)
+any_scripts=$(ls /usr/share/clearwater/clearwater-config-manager/scripts/config_validation/* 2> /dev/null)
+if [ "$any_scripts" != "" ]
+then
+  echo "Validating /etc/clearwater/shared_config"
+  ignored_error=false
+  for script in /usr/share/clearwater/clearwater-config-manager/scripts/config_validation/*
+  do
+    if [ -x "$script" ]
+    then
+      # Script is executable.  Run it
+      "$script"
+      rc=$?
+
+      # Check the return code and abort if appropriate.
+      if [ $rc != 0 ]
+      then
+        # Abort unless forcing
+        if $force
+        then
+          ignored_error=true
+        else
+          echo "Validation of /etc/clearwater/shared_config failed - aborting upload"
+          exit $rc
+        fi
+      fi
+    fi
+  done
+
+  if $ignored_error
+  then
+    echo "Validation of /etc/clearwater/shared_config failed - continuing upload"
+  else
+    echo "Validation of /etc/clearwater/shared_config succeeded"
+  fi
+fi
+
 # Fill out audit log with changes to shared_config
 keypath=http://${management_local_ip:-$local_ip}:4000/v2/keys/$etcd_key/$local_site_name/configuration/shared_config
 python /usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py $keypath


### PR DESCRIPTION
This PR implements an infrastructure that allows an integrator (and potentially Project Clearwater itself at some point in the future) to supply a config validation script that will be run when shared_config is uploaded.  Such a script could, for example, check that the user has not changed any config parameters whose values must take mandatory values in a given deployment, or verify that any hostnames in the configuration can be resolved as expected in DNS.

Under this PR, upload_shared_config looks for executable files in /usr/share/clearwater/clearwater-config-manager/scripts/config_validation and runs them, interpreting any non-zero exit code as meaning "config has failed validation".  It its the responsibility of the script to echo/print any error details to STDOUT - these will appear on screen between "Validating..." and "Validation completed successfully/with error" messages.

If the existing "--force" parameter is supplied, validation is still performed (and error output will appear on screen), but the message displayed in the event of error is "Validation failed - continuing upload", and upload is performed regardless of the success or failure of validation.

Note that I haven't added any documentation of this feature to readthedocs.  Is there an area for intergrators that this should be documented in?