### PR TITLE
[Reviewer: Richard] Recover when the shared_config key is empty

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
@@ -46,6 +46,28 @@ def main():
     # URL of shared_config etcd key
     url = sys.argv[1]
 
+    old_config_lines = []
+    new_config_lines = []
+
+    try:
+        # Get the new version of shared config from file, and the old version
+        # from etcd. If either of these fail, bail out of trying to log the
+        # the changes, and let upload_shared_config handle the errors. The
+        # exception to this is when the returned data from etcd doesn't have the
+        # right format; this is likely because the shared config key doesn't
+        # exist yet (and if it's something more complicated then again
+        # upload_shared_config can handle it).
+        new_config_lines = open("/etc/clearwater/shared_config").read().splitlines()
+        jsonstr = requests.get(url).text
+
+        try:
+            # etcd returns JSON; the shared_config is in node.value.
+            old_config_lines = json.loads(jsonstr)["node"]["value"].splitlines()
+        except KeyError:
+            pass
+    except Exception:
+        return
+
     # Get the old shared_config stored on etcd. No error checking here, as if
     # something is wrong with etcd, upload_shared_config will worry about it for us
     jsonstr = requests.get(url).text

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
@@ -68,14 +68,6 @@ def main():
     except Exception:
         return
 
-    # Get the old shared_config stored on etcd. No error checking here, as if
-    # something is wrong with etcd, upload_shared_config will worry about it for us
-    jsonstr = requests.get(url).text
-
-    new_config_lines = open("/etc/clearwater/shared_config").read().splitlines()
-    # etcd returns JSON; the shared_config is in node.value
-    old_config_lines = json.loads(jsonstr)["node"]["value"].splitlines()
-
     # We're looking to log meaningful configuration changes, so sort the lines to
     # ignore changes in line ordering
     new_config_lines.sort()


### PR DESCRIPTION
This PR adds a check that we've got old and new shared config before attempting to log them to syslog. 

Tested live (checking that adding/updating shared_config doesn't give any error messages, and logs useful output to the screen/syslog).

Fixes https://github.com/Metaswitch/clearwater-etcd-plugins/issues/16