### PR TITLE
[Reviewer: Ellie] Adds pretty print for dns_config

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-dns-configuration
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-dns-configuration
@@ -1,0 +1,90 @@
+#! /usr/bin/python
+
+# @file print-dns-configuration
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import json, sys
+from textwrap import dedent
+
+# Expected format for the dns_config file
+EXPECTED_FORMAT = dedent("""The expected format is:\n\
+{
+\"hostnames\" :
+ [
+   {
+     \"name\" : \"<hostname 1>\",
+     \"records\" : [{\"rrtype\": \"CNAME\", \"target\": \"<target for hostname 1>\"}]
+   },
+   {
+     \"name\" : \"<hostname 1>\",
+     \"records\" : [{\"rrtype\": \"CNAME\", \"target\": \"<target for hostname 1>\"}]
+   },
+   ...
+ ]
+}""")
+
+source = sys.argv[1] if len(sys.argv) > 1 else "/etc/clearwater/dns_config"
+
+# This does some basic validation of the dns configuration file, and
+# prints the contents
+try:
+    with open(source) as dns_file:
+        try:
+            dns_data = json.load(dns_file)
+            hostnames = dns_data["hostnames"]
+
+            try:
+                for hostname in hostnames:
+                    name = hostname["name"]
+                    records = hostname["records"]
+
+                    print "  Name: {}".format(name)
+                    print "  Records:"
+                    for record in records:
+                        if record["rrtype"] != "CNAME":
+                            print "Only CNAME records are supported"
+                            raise KeyError
+                        print "    rrtype: {}, target: {}".format(record["rrtype"], record["target"])
+                    print ""
+
+            except KeyError as e:
+                print "Invalid DNS entry detected in file.\n"
+                print EXPECTED_FORMAT
+
+        except ValueError, KeyError:
+            print "\nInvalid DNS file at %s\n" % source
+            print EXPECTED_FORMAT
+
+except IOError:
+    print "\nNo DNS file at %s\n" % source


### PR DESCRIPTION
Tested live. On file:
```
{
  "hostnames": [
    {
      "name": "<hostname 1>",
      "records": [{"rrtype": "CNAME", "target": "<target for hostname 1>"}, {"rrtype": "CNAME", "target": "<target for hostname 1>"}]
    },
    {
      "name": "<hostname 2>",
      "records": [{"rrtype": "CNAME", "target": "<target for hostname 2>"}]
    }
  ]
}
```

It prints out:
```
  Name: <hostname 1>
  Records:
    rrtype: CNAME, target: <target for hostname 1>
    rrtype: CNAME, target: <target for hostname 1>

  Name: <hostname 2>
  Records:
    rrtype: CNAME, target: <target for hostname 2>
```


It supports multiple records, should we choose to implement that at a later stage. 
It also currently polices records being CNAME records, as this is all we support at the moment. If rrtype is not CNAME, it will print a helpful error message.

I'm going to update all the print scripts later to return something helpful when run on an empty template file.