### PR TITLE
[Reviewer: Seb] Use pyzmq 16.0.2

### DIFF
--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.cluster_manager.test',
-    install_requires=["docopt", "pyzmq==15.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared", "py2-ipaddress==3.4.1"],
+    install_requires=["docopt", "pyzmq==16.0.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared", "py2-ipaddress==3.4.1"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.config_manager.test',
-    install_requires=["docopt", "pyzmq==15.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt", "pyzmq==16.0.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/plugins_setup.py
+++ b/plugins_setup.py
@@ -48,5 +48,5 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.plugin_tests',
-    tests_require=["pyzmq==16.1.0", "metaswitchcommon", "py2-ipaddress==3.4.1", "pbr==1.6", "Mock", "pyyaml==3.11"],
+    tests_require=["pyzmq==16.0.2", "metaswitchcommon", "py2-ipaddress==3.4.1", "pbr==1.6", "Mock", "pyyaml==3.11"],
     )

--- a/plugins_setup.py
+++ b/plugins_setup.py
@@ -48,5 +48,5 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.plugin_tests',
-    tests_require=["pyzmq==15.2", "metaswitchcommon", "py2-ipaddress==3.4.1", "pbr==1.6", "Mock", "pyyaml==3.11"],
+    tests_require=["pyzmq==16.1.0", "metaswitchcommon", "py2-ipaddress==3.4.1", "pbr==1.6", "Mock", "pyyaml==3.11"],
     )

--- a/queue_mgr_setup.py
+++ b/queue_mgr_setup.py
@@ -48,6 +48,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.queue_manager.test',
-    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==15.2", "futures==3.0.5", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==16.0.2", "futures==3.0.5", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/shared_setup.py
+++ b/shared_setup.py
@@ -46,6 +46,6 @@ setup(
     package_data={
         '': ['*.eml'],
         },
-    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==15.2", "pyyaml==3.11"],
+    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==16.0.2", "pyyaml==3.11"],
     tests_require=["Mock"],
     )


### PR DESCRIPTION
Move to use pyzmq 16.0.2, as this doesn't give us the warning text when upgrading clearwater-etcd. I've done some kick the tyres testing and this doesn't break anything. 

Fixes #258 

I'll update everything else that uses pyzmq as well.