### PR TITLE
[Reviewer: Seb] Convert MaxRetryErrors to WatchTimeout errors

### DIFF
--- a/shared_setup.py
+++ b/shared_setup.py
@@ -46,6 +46,8 @@ setup(
     package_data={
         '': ['*.eml'],
         },
+    # Note - if you are updating the version of python-etcd, check if you should
+    # remove the monkeypatch in the common_etcd_synchronizer
     install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==15.2", "pyyaml==3.11"],
     tests_require=["Mock"],
     )

--- a/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
@@ -56,6 +56,7 @@
 import etcd
 from threading import Thread
 from time import sleep
+from functools import wraps
 import logging
 import traceback
 import os
@@ -69,7 +70,8 @@ _log = logging.getLogger(__name__)
 import urllib3
 from contextlib import contextmanager
 from socket import timeout as SocketTimeout
-from urllib3.exceptions import ReadTimeoutError, ProtocolError
+from socket import error as SocketError
+from urllib3.exceptions import ReadTimeoutError, ProtocolError, MaxRetryError, HTTPError
 from urllib3.connection import HTTPException, BaseSSLError
 @contextmanager
 def _error_catcher(self): # pragma: no cover
@@ -120,6 +122,129 @@ def _error_catcher(self): # pragma: no cover
             self.release_conn()
 urllib3.HTTPResponse._error_catcher = _error_catcher
 
+# Monkeypatch python-etcd to catch MaxRetryErrors. This is a hacky fix to cover
+# https://github.com/jplana/python-etcd/issues/160 (it doesn't cover why
+# urllib3 is hitting a MaxRetryError in the first place). We should remove this
+# if we update the python-etcd version
+def _patched_wrap_request(payload): # pragma: no cover
+    @wraps(payload)
+    def wrapper(self, path, method, params=None, timeout=None):
+        some_request_failed = False
+        response = False
+
+        if timeout is None:
+            timeout = self.read_timeout
+
+        if timeout == 0:
+            timeout = None
+
+        if not path.startswith('/'):
+            raise ValueError('Path does not start with /')
+
+        while not response:
+            try:
+                response = payload(self, path, method,
+                                   params=params, timeout=timeout)
+                # Check the cluster ID hasn't changed under us.  We use
+                # preload_content=False above so we can read the headers
+                # before we wait for the content of a watch.
+                self._check_cluster_id(response)
+                # Now force the data to be preloaded in order to trigger any
+                # IO-related errors in this method rather than when we try to
+                # access it later.
+                _ = response.data
+                # urllib3 doesn't wrap all httplib exceptions and earlier versions
+                # don't wrap socket errors either.
+            except (HTTPError, MaxRetryError, HTTPException, SocketError) as e:
+                if (isinstance(params, dict) and
+                    params.get("wait") == "true" and
+                    (isinstance(e,
+                                urllib3.exceptions.MaxRetryError) or
+                     isinstance(e,
+                                urllib3.exceptions.ReadTimeoutError))):
+                    _log.debug("Watch timed out.")
+                    raise etcd.EtcdWatchTimedOut(
+                        "Watch timed out: %r" % e,
+                        cause=e
+                    )
+                _log.error("Request to server %s failed: %r",
+                           self._base_uri, e)
+
+                if self._allow_reconnect:
+                    _log.info("Reconnection allowed, looking for another "
+                              "server.")
+                    # _next_server() raises EtcdException if there are no
+                    # machines left to try, breaking out of the loop.
+                    self._base_uri = self._next_server(cause=e)
+                    some_request_failed = True
+                    # if exception is raised on _ = response.data
+                    # the condition for while loop will be False
+                    # but we should retry
+                    response = False
+                else:
+                    _log.debug("Reconnection disabled, giving up.")
+                    raise etcd.EtcdConnectionFailed(
+                        "Connection to etcd failed due to %r" % e,
+                        cause=e
+                    )
+            except etcd.EtcdClusterIdChanged as e:
+                _log.warning(e)
+                raise
+            except:
+                _log.exception("Unexpected request failure, re-raising.")
+                raise
+
+            if some_request_failed:
+                if not self._use_proxies:
+                    # The cluster may have changed since last invocation
+                    self._machines_cache = self.machines
+                self._machines_cache.remove(self._base_uri)
+        return self._handle_server_response(response)
+    return wrapper
+
+@_patched_wrap_request
+def api_execute_json_with_patched_decorator(self, path, method, params=None, timeout=None):
+    url = self._base_uri + path
+    json_payload = json.dumps(params)
+    headers = self._get_headers()
+    headers['Content-Type'] = 'application/json'
+    return self.http.urlopen(method,
+                             url,
+                             body=json_payload,
+                             timeout=timeout,
+                             redirect=self.allow_redirect,
+                             headers=headers,
+                             preload_content=False)
+etcd.Client.api_execute_json = api_execute_json_with_patched_decorator
+
+@_patched_wrap_request
+def api_execute_with_patched_decorator(self, path, method, params=None, timeout=None):
+    """ Executes the query. """
+    url = self._base_uri + path
+    if (method == self._MGET) or (method == self._MDELETE):
+        return self.http.request(
+            method,
+            url,
+            timeout=timeout,
+            fields=params,
+            redirect=self.allow_redirect,
+            headers=self._get_headers(),
+            preload_content=False)
+
+    elif (method == self._MPUT) or (method == self._MPOST):
+        return self.http.request_encode_body(
+            method,
+            url,
+            fields=params,
+            timeout=timeout,
+            encode_multipart=False,
+            redirect=self.allow_redirect,
+            headers=self._get_headers(),
+            preload_content=False)
+    else:
+        raise etcd.EtcdException(
+            'HTTP method {} not supported'.format(method))
+etcd.Client.api_execute = api_execute_with_patched_decorator
 
 class CommonEtcdSynchronizer(object):
     PAUSE_BEFORE_RETRY_ON_EXCEPTION = 30


### PR DESCRIPTION
This PR patches python-etcd to catch MaxRetryErrors when we're waiting on a key. Tested live.

Fixes #324 