### PR TITLE
[No reviewer] Use group for cluster/config managers

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/conf/clearwater-cluster-manager.monit
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/conf/clearwater-cluster-manager.monit
@@ -1,7 +1,8 @@
 # Check the clearwater-cluster-manager process.
 
 # Monitor the service's PID file and memory use.
-check process clearwater_cluster_manager with pidfile /var/run/clearwater-cluster-manager.pid
+check process clearwater_cluster_manager_process with pidfile /var/run/clearwater-cluster-manager.pid
+  group clearwater_cluster_manager
 
   start program = "/bin/bash -c '/etc/init.d/clearwater-cluster-manager start'"
   stop program = "/bin/bash -c '/etc/init.d/clearwater-cluster-manager stop'"

--- a/clearwater-config-manager.root/usr/share/clearwater/conf/clearwater-config-manager.monit
+++ b/clearwater-config-manager.root/usr/share/clearwater/conf/clearwater-config-manager.monit
@@ -1,7 +1,8 @@
 # Check the clearwater-config-manager process.
 
 # Monitor the service's PID file and memory use.
-check process clearwater_config_manager with pidfile /var/run/clearwater-config-manager.pid
+check process clearwater_config_manager_process with pidfile /var/run/clearwater-config-manager.pid
+  group clearwater_config_manager
 
   start program = "/bin/bash -c '/etc/init.d/clearwater-config-manager start'"
   stop program = "/bin/bash -c '/etc/init.d/clearwater-config-manager stop'"


### PR DESCRIPTION
Move to using a group for the cluster/config managers, to make it consistent with the queue-manager/etcd.