### PR TITLE
[Reviewer: Graeme] Update load_from scripts

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster
@@ -36,7 +36,8 @@
 
 set -ue
 
-signaling_namespace=
+. /usr/share/clearwater/utils/check-root-permissions 1
+
 etcd_key=clearwater
 . /etc/clearwater/config
 
@@ -48,4 +49,4 @@ fi
 
 node_type=$1
 
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py "${management_local_ip:-$local_ip}" "$node_type" "$signaling_namespace" "$etcd_key"
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py "${management_local_ip:-$local_ip}" "$node_type" "$etcd_key"

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
@@ -39,8 +39,7 @@ import json
 
 local_ip = sys.argv[1]
 node_type = sys.argv[2]
-sig_namespace = sys.argv[3]
-etcd_key = sys.argv[4]
+etcd_key = sys.argv[3]
 
 assert os.path.exists("/etc/init.d/cassandra"), \
     "This script should be run on a node that's running Cassandra"
@@ -53,10 +52,7 @@ try:
     # output as valid yaml, we need to use tr to replace tabs with spaces.
     # We remove any xss=.., as this can be printed out by 
     # cassandra-env.sh
-    command = "nodetool describecluster | grep -v \"^xss = \" | tr \"\t\" \" \""
-    if sig_namespace:
-        command = "ip netns exec {} ".format(sig_namespace) + command
-
+    command = "/usr/share/clearwater/bin/run-in-signaling-namespace nodetool describecluster | grep -v \"^xss = \" | tr \"\t\" \" \""
     desc_cluster_output = subprocess.check_output(command, shell=True)
     doc = yaml.load(desc_cluster_output)
     servers = doc["Cluster Information"]["Schema versions"].values()[0]

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_chronos_cluster.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_chronos_cluster.py
@@ -49,15 +49,20 @@ assert os.path.exists("/etc/init.d/chronos"), \
 etcd_key = "/{}/{}/{}/clustering/chronos".format(etcd_key, site_name, node_type)
 
 with open('/etc/chronos/chronos_cluster.conf') as f:
-    nodes = []
+    nodes = {}
+
     for line in f.readlines():
         line = line.strip().replace(' ','')
         if '=' in line:
             key, value = line.split("=")
-            assert key != "leaving", "Must not have any leaving entries when running this script"
             if key == "node":
-                nodes.append(value)
-    data = json.dumps({node: "normal" for node in nodes})
+                nodes[value] = "normal"
+            elif key == "leaving":
+                nodes[value] = "leaving"
+            elif key == "joining":
+                nodes[value] = "joining"
+
+    data = json.dumps(nodes)
 
 print "Inserting data %s into etcd key %s" % (data, etcd_key)
 


### PR DESCRIPTION
This PR updates the load_from scripts so that they can be run on unstable clusters, and makes them use the run-in-signaling-namespace script. It also removes the force* options from etcd; these are no longer supported.

This PR is part of the work to fix up the etcd recovery process after loss of quorum - these changes have been live tested as part of that work.
