### PR TITLE
[No reviewer] Print expected format if config files present but empty

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-bgcf-configuration
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-bgcf-configuration
@@ -61,39 +61,44 @@ try:
             bgcf_data = json.load(bgcf_file)
             routes = bgcf_data["routes"]
 
-            try:
-                for bgcf_route in routes:
-                    name = bgcf_route["name"]
-                    route = bgcf_route["route"]
-                    value = ""
-                    value_count = 0
+            if routes:
+                try:
+                    for bgcf_route in routes:
+                        name = bgcf_route["name"]
+                        route = bgcf_route["route"]
+                        value = ""
+                        value_count = 0
 
-                    try:
-                        domain = bgcf_route["domain"]
-                        value = "Domain: " + domain
-                        value_count += 1
-                    except KeyError as e:
-                        pass
+                        try:
+                            domain = bgcf_route["domain"]
+                            value = "Domain: " + domain
+                            value_count += 1
+                        except KeyError as e:
+                            pass
 
-                    try:
-                        number = bgcf_route["number"]
-                        value = "Number: " + number
-                        value_count += 1
-                    except KeyError as e:
-                        pass
+                        try:
+                            number = bgcf_route["number"]
+                            value = "Number: " + number
+                            value_count += 1
+                        except KeyError as e:
+                            pass
 
-                    if value_count != 1:
-                        raise KeyError
+                        if value_count != 1:
+                            raise KeyError
 
-                    print "  Name: {}".format(name)
-                    print "  {}".format(value)
-                    print "  Route: "
-                    for route_part in route:
-                        print "    {}".format(route_part)
-                    print ""
+                        print "  Name: {}".format(name)
+                        print "  {}".format(value)
+                        print "  Route: "
+                        for route_part in route:
+                            print "    {}".format(route_part)
+                        print ""
 
-            except KeyError as e:
-                print "Invalid BGCF entry detected in file.\n"
+                except KeyError as e:
+                    print "Invalid BGCF entry detected in file.\n"
+                    print EXPECTED_FORMAT
+
+            else:
+                print "Configuration file is present, but contains no entries.\n"
                 print EXPECTED_FORMAT
 
         except ValueError, KeyError:

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-dns-configuration
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-dns-configuration
@@ -64,22 +64,27 @@ try:
             dns_data = json.load(dns_file)
             hostnames = dns_data["hostnames"]
 
-            try:
-                for hostname in hostnames:
-                    name = hostname["name"]
-                    records = hostname["records"]
+            if hostnames:
+                try:
+                    for hostname in hostnames:
+                        name = hostname["name"]
+                        records = hostname["records"]
 
-                    print "  Name: {}".format(name)
-                    print "  Records:"
-                    for record in records:
-                        if record["rrtype"] != "CNAME":
-                            print "Only CNAME records are supported"
-                            raise KeyError
-                        print "    rrtype: {}, target: {}".format(record["rrtype"], record["target"])
-                    print ""
+                        print "  Name: {}".format(name)
+                        print "  Records:"
+                        for record in records:
+                            if record["rrtype"] != "CNAME":
+                                print "Only CNAME records are supported"
+                                raise KeyError
+                            print "    rrtype: {}, target: {}".format(record["rrtype"], record["target"])
+                        print ""
 
-            except KeyError as e:
-                print "Invalid DNS entry detected in file.\n"
+                except KeyError as e:
+                    print "Invalid DNS entry detected in file.\n"
+                    print EXPECTED_FORMAT
+
+            else:
+                print "Configuration file is present, but contains no entries.\n"
                 print EXPECTED_FORMAT
 
         except ValueError, KeyError:

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-enum-configuration
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-enum-configuration
@@ -61,19 +61,24 @@ try:
             enum_data = json.load(enum_file)
             blocks = enum_data["number_blocks"]
 
-            try:
-                for block in blocks:
-                    name = block["name"]
-                    prefix = block["prefix"]
-                    regex = block["regex"]
+            if blocks:
+                try:
+                    for block in blocks:
+                        name = block["name"]
+                        prefix = block["prefix"]
+                        regex = block["regex"]
 
-                    print "  Name: {}".format(name)
-                    print "  Prefix: {}".format(prefix)
-                    print "  Regex: {}".format(regex)
-                    print ""
+                        print "  Name: {}".format(name)
+                        print "  Prefix: {}".format(prefix)
+                        print "  Regex: {}".format(regex)
+                        print ""
 
-            except KeyError as e:
-                print "Invalid ENUM entry detected in file.\n"
+                except KeyError as e:
+                    print "Invalid ENUM entry detected in file.\n"
+                    print EXPECTED_FORMAT
+
+            else:
+                print "Configuration file is present, but contains no entries.\n"
                 print EXPECTED_FORMAT
 
         except ValueError, KeyError:

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-s-cscf-configuration
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-s-cscf-configuration
@@ -62,21 +62,26 @@ try:
             scscf_data = json.load(scscf_file)
             scscfs = scscf_data["s-cscfs"]
 
-            try:
-                for scscf in scscfs:
-                    server = scscf["server"]
-                    priority = scscf["priority"]
-                    weight = scscf["weight"]
-                    capabilities = scscf["capabilities"]
+            if scscfs:
+                try:
+                    for scscf in scscfs:
+                        server = scscf["server"]
+                        priority = scscf["priority"]
+                        weight = scscf["weight"]
+                        capabilities = scscf["capabilities"]
 
-                    print "  Server: {}".format(server)
-                    print "  Priority: {}".format(priority)
-                    print "  Weight: {}".format(weight)
-                    print "  Capabilities: {}".format(capabilities)
-                    print ""
+                        print "  Server: {}".format(server)
+                        print "  Priority: {}".format(priority)
+                        print "  Weight: {}".format(weight)
+                        print "  Capabilities: {}".format(capabilities)
+                        print ""
 
-            except KeyError as e:
-                print "Invalid S-CSCF entry detected in file.\n"
+                except KeyError as e:
+                    print "Invalid S-CSCF entry detected in file.\n"
+                    print EXPECTED_FORMAT
+
+            else:
+                print "Configuration file is present, but contains no entries.\n"
                 print EXPECTED_FORMAT
 
         except ValueError, KeyError:


### PR DESCRIPTION
For each pretty-print script for the plugin config files, prints `Configuration file is present, but contains no entries`, followed by the expected format, if the file present is the default template.