### PR TITLE
[Reviewer: Ellie] Do not install dns_config_plugin

### DIFF
--- a/debian/clearwater-config-manager.install
+++ b/debian/clearwater-config-manager.install
@@ -3,4 +3,6 @@ clearwater-config-manager.root/* /
 
 # Install the etcd plugins
 src/clearwater_etcd_plugins/clearwater_config_manager/shared_config_plugin.py /usr/share/clearwater/clearwater-config-manager/plugins/
-src/clearwater_etcd_plugins/clearwater_config_manager/dns_config_plugin.py /usr/share/clearwater/clearwater-config-manager/plugins/
+# For v10, we do not want the DNS config plugin in place, as it creates an
+# unused config file, which can then create spurious output in scripts
+# src/clearwater_etcd_plugins/clearwater_config_manager/dns_config_plugin.py /usr/share/clearwater/clearwater-config-manager/plugins/

--- a/debian/clearwater-config-manager.install
+++ b/debian/clearwater-config-manager.install
@@ -3,6 +3,6 @@ clearwater-config-manager.root/* /
 
 # Install the etcd plugins
 src/clearwater_etcd_plugins/clearwater_config_manager/shared_config_plugin.py /usr/share/clearwater/clearwater-config-manager/plugins/
-# For v10, we do not want the DNS config plugin in place, as it creates an
+# We do not want the DNS config plugin in place atm, as it creates an
 # unused config file, which can then create spurious output in scripts
 # src/clearwater_etcd_plugins/clearwater_config_manager/dns_config_plugin.py /usr/share/clearwater/clearwater-config-manager/plugins/


### PR DESCRIPTION
This stops the dns_config_plugin being put in place, stopping us creating an unused config file.
This stops scripts such as check_config_sync reporting the config state, which might confuse users.

Tested live, and this seems to work fine. Just want you to have a quick look, in case you think this will somehow break other things.

My plan for merging will be as discussed:

* merge this into rel-114-fixes
* merge fixes down into dev
* revert the change as a new commit to merge into dev, so that we avoid conflicts down the line as much as possible

Sound reasonable? 