### PR TITLE
[No reviewer] Fixup printout of expected format

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-s-cscf-configuration
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/print-s-cscf-configuration
@@ -44,9 +44,9 @@ EXPECTED_FORMAT = dedent("""The expected format is:\n\
  [
    {
      \"server\" : \"<S-CSCF URI>\",
-     \"priority\" : \"<priority>\",
-     \"weight\" : \"<weight>\",
-     \"capabilities\" : \"[<comma separated capabilities>]\",
+     \"priority\" : <priority>,
+     \"weight\" : <weight>,
+     \"capabilities\" : [<comma separated capabilities>],
    },
    ...
  ]


### PR DESCRIPTION
Fixup expected format to be correct, and match http://clearwater.readthedocs.io/en/stable/Manual_Install.html#i-cscf-configuration. 