### PR TITLE
[Reviewer: Ellie] Cassandra uts

### DIFF
--- a/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
@@ -49,7 +49,7 @@ from metaswitch.clearwater.cluster_manager.plugin_utils import WARNING_HEADER
 # used in the plugin to check the system state via a set of state flags. This
 # can be set up in each test to simulate a specific system state, rather than
 # needing a separate side effect definition for each.
-class mock_exists(object):
+class mock_existing_files(object):
     def __init__(self, state_flags):
         self.existing_flags = state_flags
 
@@ -112,7 +112,7 @@ seed_provider:\n\
 
         # Return for all os.path.exists checks, to simulate no state flags
         flags = []
-        mock_os_path.side_effect = mock_exists(flags)
+        mock_os_path.side_effect = mock_existing_files(flags)
 
         # Call startup actions, as the FSM would
         self.plugin.on_startup(self.test_cluster_view)
@@ -144,7 +144,7 @@ seed_provider:\n\
 
         # Set up the state to be returned by mock_path_exists
         flags = ["/etc/clearwater/force_cassandra_yaml_refresh", "/etc/cassandra/cassandra.yaml"]
-        mock_os_path.side_effect = mock_exists(flags)
+        mock_os_path.side_effect = mock_existing_files(flags)
 
         # Call startup actions, as the FSM would. As 'force_cassandra_yaml_refresh'
         # is in place, as is the case on upgrade, we test the full 'on_startup' flow
@@ -230,7 +230,7 @@ seed_provider:\n\
            and perform a full destructive restart."""
         # Set up conditions and test data
         flags = [self.plugin.CASSANDRA_YAML_FILE]
-        mock_os_path.side_effect = mock_exists(flags)
+        mock_os_path.side_effect = mock_existing_files(flags)
 
         # Call join cluster as the FSM would
         with mock.patch('clearwater_etcd_plugins.clearwater_cassandra.cassandra_plugin.open', mock.mock_open(read_data=self.test_yaml_template), create=True) as mock_open:
@@ -285,7 +285,7 @@ seed_provider:\n\
         # Set up the state to be returned by mock_path_exists
         flags = [self.plugin.CASSANDRA_YAML_FILE,
                  self.plugin.BOOTSTRAP_IN_PROGRESS_FLAG]
-        mock_os_path.side_effect = mock_exists(flags)
+        mock_os_path.side_effect = mock_existing_files(flags)
 
         # Call join cluster as the FSM would
         with mock.patch('clearwater_etcd_plugins.clearwater_cassandra.cassandra_plugin.open', mock.mock_open(read_data=self.test_yaml_template), create=True) as mock_open:
@@ -344,7 +344,7 @@ seed_provider:\n\
         # Set up the state to be returned by mock_path_exists
         flags = [self.plugin.CASSANDRA_YAML_FILE,
                  self.plugin.BOOTSTRAPPED_FLAG]
-        mock_os_path.side_effect = mock_exists(flags)
+        mock_os_path.side_effect = mock_existing_files(flags)
 
         # Call join cluster as the FSM would
         with mock.patch('clearwater_etcd_plugins.clearwater_cassandra.cassandra_plugin.open', mock.mock_open(read_data=self.test_yaml_template), create=True) as mock_open:
@@ -398,7 +398,7 @@ seed_provider:\n\
         flags = [self.plugin.CASSANDRA_YAML_FILE,
                  self.plugin.BOOTSTRAP_IN_PROGRESS_FLAG,
                  self.plugin.BOOTSTRAPPED_FLAG]
-        mock_os_path.side_effect = mock_exists(flags)
+        mock_os_path.side_effect = mock_existing_files(flags)
 
         # Call leave cluster as the FSM would
         self.plugin.on_leaving_cluster(self.test_cluster_view)

--- a/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
@@ -391,8 +391,12 @@ seed_provider:\n\
                                        mock_run_command):
         """Test the cassandra_plugin leaving process
         We should make sure that the bootstrapped flag is removed once we leave"""
-        # Set up the state to be returned by mock_path_exists
+        # Set up the state to be returned by mock_path_exists. We wouldn't
+        # normally expect both the bootstrap_in_progress and bootstrapping
+        # flags to be present at the same time, but to make sure we remove
+        # them without needing two near identical tests, we'll set them both here.
         flags = [self.plugin.CASSANDRA_YAML_FILE,
+                 self.plugin.BOOTSTRAP_IN_PROGRESS_FLAG,
                  self.plugin.BOOTSTRAPPED_FLAG]
         mock_os_path.side_effect = mock_exists(flags)
 
@@ -412,9 +416,11 @@ seed_provider:\n\
 
         path_exists_call_list = \
             [mock.call(self.plugin.CASSANDRA_YAML_FILE),
+             mock.call(self.plugin.BOOTSTRAP_IN_PROGRESS_FLAG),
              mock.call(self.plugin.BOOTSTRAPPED_FLAG)]
         path_remove_call_list = \
             [mock.call(self.plugin.CASSANDRA_YAML_FILE),
+             mock.call(self.plugin.BOOTSTRAP_IN_PROGRESS_FLAG),
              mock.call(self.plugin.BOOTSTRAPPED_FLAG)]
 
         mock_os_path.assert_has_calls(path_exists_call_list)


### PR DESCRIPTION
Remember, you asked for these...

As the per commit messages:

* first commit is purely refactoring, not adding/changing tests. This means that adding the new tests doesn't mean adding loads of lines of copy-paste boiler plate setup.
* second commit is the main chunk. It adds the mock_exists class to be used as a side_effect in the unit tests. It takes a list of flags (files) that exist on the hypothetical test system, and then when called as the side effect of mocked os.path.exists returns true/false correctly.
* third commit is just a small change to go along with a markup to the actual plugin

Tests also pass verify and coverage :smiley: 