### PR TITLE
[Reviewer: Ellie] Less aggresssive alarms from poll_etcd_cluster.sh

### DIFF
--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
@@ -35,15 +35,16 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 # This script is used by Monit to check connectivity to remote etcd instances.
-# If connectivity is lost to any instances in the cluster an alarm will be
-# issued (major severity for a single instance, critical severity if enough
-# instances are unreachable that quorum can't be formed). When connectivity is
-# restored to all instances, the alarm is cleared. Alarms are issued here vs.
-# the Monit DSL to avoid retransmissions.
+# If connectivity is lost to any instances in the cluster, an alarm severity is
+# written to the alarm_waiting_file. When monit notices that the cluster is
+# unhealthy for a period of time, it raises the appropriate alarm (major
+# severity for a single instance, critical severity if enough instances are
+# unreachable that quorum can't be formed). When connectivity is restored to all
+# instances, the alarm is cleared.
 #
 # Execution of etcdctl is "niced" to minimize the impact of its use.
 
-alarm_state_file="/tmp/.clearwater_etcd_alarm_issued"
+alarm_waiting_file="/tmp/.clearwater_etcd_alarm_waiting"
 
 . /etc/clearwater/config
 export ETCDCTL_PEERS=http://${management_local_ip:-$local_ip}:4000
@@ -83,44 +84,21 @@ cluster_state()
 }
 
 
-check_clear_alarm()
-{
-    if [ -f $alarm_state_file ] ; then
-        rm -f $alarm_state_file
-        /usr/share/clearwater/bin/issue-alarm "monit" "6501.1"
-    fi
-}
-
-
-check_issue_major_alarm()
-{
-    if [ ! -f $alarm_state_file ] || [ `cat $alarm_state_file` != "major" ] ; then
-        echo "major" > $alarm_state_file
-        /usr/share/clearwater/bin/issue-alarm "monit" "6501.4"
-    fi
-}
-
-
-check_issue_critial_alarm()
-{
-    if [ ! -f $alarm_state_file ] || [ `cat $alarm_state_file` != "critical" ] ; then
-        echo "critical" > $alarm_state_file
-        /usr/share/clearwater/bin/issue-alarm "monit" "6501.3"
-    fi
-}
-
-
 cluster_state
 state=$?
 
 echo $state
 
+# If the cluster is healthy, remove alarm file and clear alarm.
+# If not, write the alarm level to the alarm_waiting_file so that monit can
+# raise the alarm.
 if [ "$state" = 0 ] ; then
-    check_clear_alarm
+    rm -f $alarm_waiting_file > /dev/null 2>&1
+    /usr/share/clearwater/bin/issue-alarm "monit" "6501.1"
 elif [ "$state" = 1 ] ; then
-    check_issue_major_alarm
+    echo "major" > $alarm_waiting_file
 else
-    check_issue_critial_alarm
+    echo "critical" > $alarm_waiting_file
 fi
 
 exit $state

--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
@@ -35,8 +35,8 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 # This script is used by Monit to check connectivity to remote etcd instances.
-# If connectivity is lost to any instances in the cluster, an alarm severity is
-# written to the alarm_waiting_file. When monit notices that the cluster is
+# If connectivity is lost to any instances in the cluster, an alarm id is
+# written to the ALARM_TO_RAISE_FILE. When monit notices that the cluster is
 # unhealthy for a period of time, it raises the appropriate alarm (major
 # severity for a single instance, critical severity if enough instances are
 # unreachable that quorum can't be formed). When connectivity is restored to all
@@ -44,7 +44,7 @@
 #
 # Execution of etcdctl is "niced" to minimize the impact of its use.
 
-alarm_waiting_file="/tmp/.clearwater_etcd_alarm_waiting"
+ALARM_TO_RAISE_FILE="/tmp/.clearwater_etcd_alarm_to_raise"
 
 . /etc/clearwater/config
 export ETCDCTL_PEERS=http://${management_local_ip:-$local_ip}:4000
@@ -90,15 +90,14 @@ state=$?
 echo $state
 
 # If the cluster is healthy, remove alarm file and clear alarm.
-# If not, write the alarm level to the alarm_waiting_file so that monit can
-# raise the alarm.
+# If not, write the alarm to the ALARM_TO_RAISE_FILE so that monit can raise it.
 if [ "$state" = 0 ] ; then
-    rm -f $alarm_waiting_file > /dev/null 2>&1
+    rm -f $ALARM_TO_RAISE_FILE > /dev/null 2>&1
     /usr/share/clearwater/bin/issue-alarm "monit" "6501.1"
 elif [ "$state" = 1 ] ; then
-    echo "major" > $alarm_waiting_file
+    echo "6501.4" > $ALARM_TO_RAISE_FILE
 else
-    echo "critical" > $alarm_waiting_file
+    echo "6501.3" > $ALARM_TO_RAISE_FILE
 fi
 
 exit $state

--- a/clearwater-etcd/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# @file raise_etcd_cluster_alarm.sh
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2017  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+alarm_waiting_file="/tmp/.clearwater_etcd_alarm_waiting"
+
+# Read in the alarm level from the alarm_waiting_file, and raise the appropriate
+# alarm
+if [ -f $alarm_waiting_file ] ; then
+    level=`cat $alarm_waiting_file`
+    if [ "$level" = "major" ] ; then
+        /usr/share/clearwater/bin/issue-alarm "monit" "6501.4"
+    else
+        /usr/share/clearwater/bin/issue-alarm "monit" "6501.3"
+    fi
+fi
+
+

--- a/clearwater-etcd/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh
@@ -36,8 +36,7 @@
 
 ALARM_TO_RAISE_FILE="/tmp/.clearwater_etcd_alarm_to_raise"
 
-# Read in the alarm level from the ALARM_TO_RAISE_FILE, and raise the appropriate
-# alarm
+# Read in the alarm from the ALARM_TO_RAISE_FILE and raise it.
 if [ -f $ALARM_TO_RAISE_FILE ] ; then
     alarm=`cat $ALARM_TO_RAISE_FILE`
     /usr/share/clearwater/bin/issue-alarm "monit" $alarm

--- a/clearwater-etcd/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh
@@ -34,17 +34,13 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-alarm_waiting_file="/tmp/.clearwater_etcd_alarm_waiting"
+ALARM_TO_RAISE_FILE="/tmp/.clearwater_etcd_alarm_to_raise"
 
-# Read in the alarm level from the alarm_waiting_file, and raise the appropriate
+# Read in the alarm level from the ALARM_TO_RAISE_FILE, and raise the appropriate
 # alarm
-if [ -f $alarm_waiting_file ] ; then
-    level=`cat $alarm_waiting_file`
-    if [ "$level" = "major" ] ; then
-        /usr/share/clearwater/bin/issue-alarm "monit" "6501.4"
-    else
-        /usr/share/clearwater/bin/issue-alarm "monit" "6501.3"
-    fi
+if [ -f $ALARM_TO_RAISE_FILE ] ; then
+    alarm=`cat $ALARM_TO_RAISE_FILE`
+    /usr/share/clearwater/bin/issue-alarm "monit" $alarm
 fi
 
 

--- a/clearwater-etcd/usr/share/clearwater/conf/clearwater-etcd.monit
+++ b/clearwater-etcd/usr/share/clearwater/conf/clearwater-etcd.monit
@@ -63,6 +63,8 @@ check program poll_etcd_cluster with path "/usr/share/clearwater/bin/poll_etcd_c
   depends on etcd_process
   every 6 cycles
   if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh'"
+    # Raise the alarm every time the above test fails
+    repeat every 1 cycles
 
 # Check that etcd is listening on 4000. This depends on the etcd process (and
 # so won't run unless the etcd process is running)

--- a/clearwater-etcd/usr/share/clearwater/conf/clearwater-etcd.monit
+++ b/clearwater-etcd/usr/share/clearwater/conf/clearwater-etcd.monit
@@ -53,14 +53,16 @@ check program etcd_uptime with path /usr/share/clearwater/infrastructure/monit_u
   every 3 cycles
   if status != 0 then alert
 
-# Monitor cluster health.  If connectivity is lost to any node issue an alarm,
-# otherwise clear it (alarm handling is done in the check script to avoid
-# unnecessary retransmissions). Only check every 60 seconds due to overhead of
-# running etcdctl cluster-health.
-check program poll_etcd_cluster with path "/usr/share/clearwater/bin/poll_etcd_cluster.sh" every 6 cycles
+# Monitor cluster health.  If connectivity is lost to any node (over 2
+# consecutive cycles) issue an alarm.
+# If the the cluster is healthy, clear any alarms (this is handled in the poll
+# script).
+# Only check every 60 seconds due to overhead of running etcdctl cluster-health.
+check program poll_etcd_cluster with path "/usr/share/clearwater/bin/poll_etcd_cluster.sh"
   group etcd
   depends on etcd_process
-  if status != 0 then alert
+  every 6 cycles
+  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/raise_etcd_cluster_alarm.sh'"
 
 # Check that etcd is listening on 4000. This depends on the etcd process (and
 # so won't run unless the etcd process is running)

--- a/debian/clearwater-etcd.postinst
+++ b/debian/clearwater-etcd.postinst
@@ -88,7 +88,7 @@ case "$1" in
         setup_user
         setup_data_dir
         setup_log_dir
-        
+
         install -D --mode=0644 /usr/share/clearwater/conf/clearwater-etcd.monit /etc/monit/conf.d/
         reload clearwater-monit || /bin/true
 
@@ -97,10 +97,14 @@ case "$1" in
         # significant lag.)
         # Don't fail if it's already stopped.
         service clearwater-etcd stop || /bin/true
-        
+
         # Clean up any pidfile still in the old location - we've moved it to
         # /var/run/clearwater-etd/clearwater-etcd.pid
         rm -f /var/run/$NAME.pid
+
+        # Clean up any old clearwater_etcd_alarm_issued file - it's no longer
+        # used
+        rm -f /tmp/.clearwater_etcd_alarm_issued
 
     ;;
 

--- a/debian/clearwater-etcd.prerm
+++ b/debian/clearwater-etcd.prerm
@@ -73,6 +73,10 @@ case "$1" in
 
           rm -rf /var/log/$NAME
           rm -rf /var/lib/$NAME
+
+          # Remove any alarm markers
+          rm -f /tmp/.clearwater_etcd_alarm_issued
+          rm -f /tmp/.clearwater_etcd_alarm_to_raise
         fi
     ;;
 


### PR DESCRIPTION
We should only alarm once we've had 2 consecutive errors (like we do for some
other poll scripts).

This is a fix for issue #407, because we believe that we get false positives from the poll_etcd_cluster script when the cluster is actually healthy.

#### Testing:
- live tested (by manually altering the poll_etcd_cluster script to return various errors)