### PR TITLE
[Reviewer: Adam] Remove *-dev packages as install-time dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,22 +11,22 @@ Homepage: http://projectclearwater.org/
 
 Package: clearwater-etcd
 Architecture: all
-Depends: python-dev, python-pip, libffi-dev, libssl-dev, clearwater-infrastructure, clearwater-monit
+Depends: python-pip, clearwater-infrastructure, clearwater-monit
 Description: etcd configured for Clearwater
 
 Package: clearwater-cluster-manager
 Architecture: all
-Depends: python-dev, python-pip, libffi-dev, libssl-dev, libzmq3-dev, python-virtualenv, clearwater-etcd, clearwater-monit
+Depends: python-pip, python-virtualenv, clearwater-etcd, clearwater-monit
 Description: Cluster manager for Clearwater
 
 Package: clearwater-queue-manager
 Architecture: all
-Depends: python-dev, python-pip, libffi-dev, libssl-dev, libzmq3-dev, python-virtualenv, clearwater-etcd, clearwater-monit
+Depends: python-pip, python-virtualenv, clearwater-etcd, clearwater-monit
 Description: Queue manager for Clearwater
 
 Package: clearwater-config-manager
 Architecture: all
-Depends: python-dev, python-pip, libffi-dev, libssl-dev, libzmq3-dev, python-virtualenv, clearwater-etcd, clearwater-queue-manager, clearwater-monit, python-requests
+Depends: python-pip, python-virtualenv, clearwater-etcd, clearwater-queue-manager, clearwater-monit, python-requests
 Description: Configuration manager for Clearwater
 
 Package: clearwater-management


### PR DESCRIPTION
I spotted that we were installing these packages, and they're unnecessary - we don't compile anything at install time so don't need header files.