### PR TITLE
Non ascii config

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
@@ -81,7 +81,7 @@ def main():
 
     additions = [line[2:] for line in difflines if line.startswith("+ ") and len(line) > 2]
     additions_str = ", ".join(['"' + line + '"' for line in additions])
- 
+
     # We'll be running as root, but SUDO_USER pulls out the user who invoked sudo
     username = os.environ['SUDO_USER']
 

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/log_shared_config.py
@@ -57,7 +57,7 @@ def main():
         # right format; this is likely because the shared config key doesn't
         # exist yet (and if it's something more complicated then again
         # upload_shared_config can handle it).
-        new_config_lines = open("/etc/clearwater/shared_config").read().splitlines()
+        new_config_lines = codecs.open("/etc/clearwater/shared_config", encoding='utf-8')
         jsonstr = requests.get(url).text
 
         try:
@@ -81,7 +81,7 @@ def main():
 
     additions = [line[2:] for line in difflines if line.startswith("+ ") and len(line) > 2]
     additions_str = ", ".join(['"' + line + '"' for line in additions])
-
+ 
     # We'll be running as root, but SUDO_USER pulls out the user who invoked sudo
     username = os.environ['SUDO_USER']
 

--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -89,7 +89,7 @@ def safely_write(filename, contents, permissions=0644):
     # delete it on close (os.rename deletes it).
     tmp = tempfile.NamedTemporaryFile(dir=dirname(filename), delete=False)
 
-    tmp.write(contents)
+    tmp.write(contents.encode("utf-8"))
 
     os.chmod(tmp.name, permissions)
 


### PR DESCRIPTION
Use encoding to handle non-ascii characters. Each commit fixes one issue. Tested by looking at config manager log in live system. Unfortunate white space but didn't want to change git history again....