### PR TITLE
[Reviewer: Seb] Document libffi-dev build dependancy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 # clearwater-infrastructure explicitly checks for packages of this name when
 # updating
 Maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), libffi-dev
 Standards-Version: 3.9.2
 Homepage: http://projectclearwater.org/
 


### PR DESCRIPTION
clearwater-etcd depends on python-common which requires libffi-dev to build the egg.