### PR TITLE
[Reviewer: Richard] Don't assume all nodes are etcd members as opposed to proxies

### DIFF
--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
@@ -89,7 +89,7 @@ cluster_state()
         fi
       done
       # add the list of healthy mambers to a state file, so we can rejoin safely if we die
-      echo "etcd_cluster=$HEALTHY_MEMBER_LIST" > "/var/lib/clearwater-etcd/healthy_etcd_members"
+      echo "$HEALTHY_MEMBER_LIST" > "/var/lib/clearwater-etcd/healthy_etcd_members"
 
       if [ $unhealthy_members ]
       then

--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -134,7 +134,13 @@ setup_etcdctl_peers()
         # that functions later in this script use the correct cluster value.
         if [ -f $HEALTHY_CLUSTER_VIEW ]
         then
-          . $HEALTHY_CLUSTER_VIEW
+          if [ -n "$etcd_cluster" ]
+          then
+            etcd_cluster=$( cat $HEALTHY_CLUSTER_VIEW )
+          elif [ -n "$etcd_proxy" ]
+          then
+            etcd_proxy=$( cat $HEALTHY_CLUSTER_VIEW )
+          fi
         fi
 
         # Build the client list based on $etcd_cluster. Each entry is simply

--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -130,16 +130,20 @@ join_cluster_as_proxy()
 setup_etcdctl_peers()
 {
         # If we were in a working cluster before, we will have saved off an up to
-        # date view of the cluster. We want to override etcd_cluster with this, so
-        # that functions later in this script use the correct cluster value.
+        # date view of the cluster. We want to override etcd_cluster or
+        # etcd_proxy with this, so that functions later in this script use the
+        # correct cluster value.
         if [ -f $HEALTHY_CLUSTER_VIEW ]
         then
+          # We want to stip anything up to and including the first = character
+          # so we can select etcd_cluster or etcd_proxy appropriately
+          healthy_cluster=$(sed -e 's/.*=//' < $HEALTHY_CLUSTER_VIEW)
           if [ -n "$etcd_cluster" ]
           then
-            etcd_cluster=$( cat $HEALTHY_CLUSTER_VIEW )
+            etcd_cluster=$healthy_cluster
           elif [ -n "$etcd_proxy" ]
           then
-            etcd_proxy=$( cat $HEALTHY_CLUSTER_VIEW )
+            etcd_proxy=$healthy_cluster
           fi
         fi
 


### PR DESCRIPTION
Save the healthy member list as just the list, and set etcd_cluster or
etcd_proxy to tat list depending on the node settings

Fix for issue: https://github.com/Metaswitch/clearwater-issues/issues/2094