### PR TITLE
[Reviewer: Richard] use etcd_proxy if it's specified, not etcd_cluster

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -151,7 +151,16 @@ setup_etcdctl_peers()
         # <IP>:<port>, using the client port. Replace commas with whitespace,
         # then split on whitespace (to cope with etcd_cluster values that have spaces)
         export ETCDCTL_PEERS=
-        for server in ${etcd_cluster//,/ }
+        servers=""
+        if [ -n "$etcd_cluster" ]
+        then
+          servers=$etcd_cluster
+        elif [ -n "$etcd_proxy" ]
+        then
+          servers=$etcd_proxy
+        fi
+
+        for server in ${servers//,/ }
         do
             if [[ $server != $advertisement_ip ]]
             then


### PR DESCRIPTION
This fixes https://github.com/Metaswitch/clearwater-issues/issues/2095

Note: you can still see an error message if you have only a single etcd master node in your cluster, and you try to restart the etcd service on that master node. This is because the only IP address it will have is its own, and it won't add that as a peer, and so won't be able to connect to get the member list.

However, if you've only got one etcd master node left, you've got bigger problems, as you should always have at least 3 master nodes (your 3 Vellum nodes if you have them, else all your nodes).