### PR TITLE
[Reviewer: EM] Improve queue manager shutdown logging

### DIFF
--- a/debian/clearwater-config-manager.init.d
+++ b/debian/clearwater-config-manager.init.d
@@ -61,7 +61,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 # to check if they exist before starting a new process).
 #
 # See also start-stop-daemon's manpage, specifically the comment on --exec: "this might not work as
-# intended with interpreted scripts, as the executable will point to the interpreter". 
+# intended with interpreted scripts, as the executable will point to the interpreter".
 DAEMON=/usr/share/clearwater/bin/clearwater-config-manager
 ACTUAL_EXEC=/usr/share/clearwater/clearwater-config-manager/env/bin/python
 
@@ -125,7 +125,7 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
+	start-stop-daemon --stop --quiet --retry=TERM/120/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
 	RETVAL="$?"
 	return "$RETVAL"
 }
@@ -142,7 +142,7 @@ do_abort()
         #   1 if daemon was already stopped
         #   2 if daemon could not be stopped
         #   other if a failure occurred
-        start-stop-daemon --stop --quiet --retry=USR1/5/TERM/30/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
+        start-stop-daemon --stop --quiet --retry=USR1/5/TERM/120/KILL/5 --exec $ACTUAL_EXEC --pidfile $PIDFILE
         RETVAL="$?"
         # If the abort failed, it may be because the PID in PIDFILE doesn't match the right process
         # In this window condition, we may not recover, so remove the PIDFILE to get it running

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -84,6 +84,18 @@ LOG_LEVELS = {'0': logging.ERROR,
               '3': logging.INFO,
               '4': logging.DEBUG}
 
+should_quit = False
+
+def install_sigquit_handler(plugins):
+    def sigquit_handler(sig, stack):
+        global should_quit
+        _log.info("Handling SIGQUIT")
+        for plugin in plugins:
+            _log.info("{} leaving cluster".format(plugin))
+            plugin.leave_cluster()
+        should_quit = True
+    signal.signal(signal.SIGQUIT, sigquit_handler)
+
 def main(args):
     syslog.openlog("cluster-manager", syslog.LOG_PID)
     pdlogs.STARTUP.log()
@@ -192,7 +204,7 @@ def main(args):
             _log.info("Loaded plugin %s" % plugin)
 
 
-    utils.install_sigquit_handler(synchronizers)
+    install_sigquit_handler(synchronizers)
     utils.install_sigterm_handler(synchronizers)
 
     while any([thread.isAlive() for thread in threads]):
@@ -201,7 +213,7 @@ def main(args):
                 thread.join(1)
 
     _log.info("No plugin threads running, waiting for a SIGTERM or SIGQUIT")
-    while not utils.should_quit:
+    while not utils.should_quit and not should_quit:
         sleep(1)
     _log.info("Quitting")
     _log.debug("%d threads outstanding at exit" % activeCount())

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -121,6 +121,7 @@ def main(args):
     plugins_dir = "/usr/share/clearwater/clearwater-config-manager/plugins/"
     plugins = load_plugins_in_dir(plugins_dir)
     plugins.sort(key=lambda x: x.key())
+    synchronizers = []
     threads = []
 
     files = [p.file() for p in plugins]
@@ -130,13 +131,19 @@ def main(args):
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, alarm, etcd_key)
         syncer.start_thread()
 
+        synchronizers.append(syncer)
         threads.append(syncer.thread)
         _log.info("Loaded plugin %s" % plugin)
+
+    utils.install_sigterm_handler(synchronizers)
 
     while any([thr.isAlive() for thr in threads]):
         for thr in threads:
             if thr.isAlive():
                 thr.join(1)
+
+    while not utils.should_quit:
+        sleep(1)
 
     _log.info("Clearwater Configuration Manager shutting down")
     pdlogs.EXITING.log()

--- a/src/metaswitch/clearwater/queue_manager/main.py
+++ b/src/metaswitch/clearwater/queue_manager/main.py
@@ -125,19 +125,26 @@ def main(args):
     plugins = load_plugins_in_dir(plugins_dir,
                                   PluginParams(wait_plugin_complete=wait_plugin_complete))
     plugins.sort(key=lambda x: x.key())
+    synchronizers = []
     threads = []
 
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, etcd_key, node_type)
         syncer.start_thread()
 
+        synchronizers.append(syncer)
         threads.append(syncer.thread)
         _log.info("Loaded plugin %s" % plugin)
+
+    utils.install_sigterm_handler(synchronizers)
 
     while any([thr.isAlive() for thr in threads]):
         for thr in threads:
             if thr.isAlive():
                 thr.join(1)
+
+    while not utils.should_quit:
+        sleep(1)
 
     _log.info("Clearwater Queue Manager shutting down")
     pdlogs.EXITING.log()


### PR DESCRIPTION
Fixes 1480 by adding a TERM handler for the queue manager (and config manager). This means that we don't just kill queue manager when stopping it and let it shut down properly which means we can log that it's been stopped. I needed to extend the timeout for config manager so that we had enough time to unload all the plugins.

Queue manager and config manager don't use the QUIT handler since they can't receive the QUIT signal.

Tested live that shutdown logs are written to the log file.