### PR TITLE
[Reviewer: EM] Only store off healthy etcd members if some exist

### DIFF
--- a/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
+++ b/clearwater-etcd/usr/share/clearwater/bin/poll_etcd_cluster.sh
@@ -62,8 +62,12 @@ cluster_state()
           parse_member_ip $line
         fi
       done
-      # add the list of healthy mambers to a state file, so we can rejoin safely if we die
-      echo "$HEALTHY_MEMBER_LIST" > "/var/lib/clearwater-etcd/healthy_etcd_members"
+      # If there are any healthy members, add them to a state file, so we can
+      # rejoin safely if we die.
+      if [[ ! -z $HEALTHY_MEMBER_LIST ]]
+      then
+        echo "$HEALTHY_MEMBER_LIST" > "/var/lib/clearwater-etcd/healthy_etcd_members"
+      fi
 
       if [ $unhealthy_members ]
       then


### PR DESCRIPTION
Avoids the case where we store an empty list of healthy members which means we can't subsequently join the etcd cluster.