### PR TITLE
Pin python dependencies in clearwater-etcd

### DIFF
--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -48,7 +48,8 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.cluster_manager.test',
-    install_requires=["docopt==0.6.2", "pyzmq==16.0.2", "urllib3==1.17",
-        "python-etcd==0.4.3", "pyyaml==3.11", "prctl==1.0.1", "metaswitchcommon", "clearwater_etcd_shared", "py2-ipaddress==3.4.1"],
+    install_requires=[
+        "clearwater_etcd_shared",
+        "metaswitchcommon"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -48,6 +48,7 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.cluster_manager.test',
-    install_requires=["docopt", "pyzmq==16.0.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared", "py2-ipaddress==3.4.1"],
+    install_requires=["docopt==0.6.2", "pyzmq==16.0.2", "urllib3==1.17",
+        "python-etcd==0.4.3", "pyyaml==3.11", "prctl==1.0.1", "metaswitchcommon", "clearwater_etcd_shared", "py2-ipaddress==3.4.1"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -51,5 +51,9 @@ setup(
     install_requires=[
         "clearwater_etcd_shared",
         "metaswitchcommon"],
-    tests_require=["pbr==1.6", "Mock"],
+    tests_require=[
+        "funcsigs==1.0.2",
+        "Mock==2.0.0",
+        "pbr==1.6",
+        "six==1.10.0"]
     )

--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -48,7 +48,8 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.config_manager.test',
-    install_requires=["docopt==0.6.2", "pyzmq==16.0.2", "urllib3==1.17",
-        "python-etcd==0.4.3", "pyyaml==3.11", "prctl==1.0.1", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=[
+        "clearwater_etcd_shared",
+        "metaswitchcommon"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -51,5 +51,9 @@ setup(
     install_requires=[
         "clearwater_etcd_shared",
         "metaswitchcommon"],
-    tests_require=["pbr==1.6", "Mock"],
+    tests_require=[
+        "funcsigs==1.0.2",
+        "Mock==2.0.0",
+        "pbr==1.6",
+        "six==1.10.0"]
     )

--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -48,6 +48,7 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.config_manager.test',
-    install_requires=["docopt", "pyzmq==16.0.2", "urllib3==1.17", "python-etcd==0.4.3", "pyyaml==3.11", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt==0.6.2", "pyzmq==16.0.2", "urllib3==1.17",
+        "python-etcd==0.4.3", "pyyaml==3.11", "prctl==1.0.1", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/queue_mgr_setup.py
+++ b/queue_mgr_setup.py
@@ -48,7 +48,8 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.queue_manager.test',
-    install_requires=["docopt==0.6.2", "urllib3==1.17", "python-etcd==0.4.3",
-        "pyzmq==16.0.2", "futures==3.0.5", "prctl==1.0.1", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=[
+        "clearwater_etcd_shared",
+        "metaswitchcommon"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/queue_mgr_setup.py
+++ b/queue_mgr_setup.py
@@ -48,6 +48,7 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.queue_manager.test',
-    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==16.0.2", "futures==3.0.5", "prctl", "metaswitchcommon", "clearwater_etcd_shared"],
+    install_requires=["docopt==0.6.2", "urllib3==1.17", "python-etcd==0.4.3",
+        "pyzmq==16.0.2", "futures==3.0.5", "prctl==1.0.1", "metaswitchcommon", "clearwater_etcd_shared"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/queue_mgr_setup.py
+++ b/queue_mgr_setup.py
@@ -51,5 +51,9 @@ setup(
     install_requires=[
         "clearwater_etcd_shared",
         "metaswitchcommon"],
-    tests_require=["pbr==1.6", "Mock"],
+    tests_require=[
+        "funcsigs==1.0.2",
+        "Mock==2.0.0",
+        "pbr==1.6",
+        "six==1.10.0"]
     )

--- a/shared_setup.py
+++ b/shared_setup.py
@@ -48,6 +48,14 @@ setup(
         },
     # Note - if you are updating the version of python-etcd, check if you should
     # remove the monkeypatch in the common_etcd_synchronizer
-    install_requires=["docopt==0.6.2", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==16.0.2", "pyyaml==3.11"],
+    install_requires=[
+        "docopt==0.6.2",
+        "futures==3.0.5",
+        "prctl==1.0.1",
+        "python-etcd==0.4.3",
+        "py2_ipaddress==3.4.1",
+        "pyyaml==3.11",
+        "six==1.10.0",
+        "urllib3==1.21.1"],
     tests_require=["Mock"],
     )

--- a/shared_setup.py
+++ b/shared_setup.py
@@ -48,6 +48,6 @@ setup(
         },
     # Note - if you are updating the version of python-etcd, check if you should
     # remove the monkeypatch in the common_etcd_synchronizer
-    install_requires=["docopt", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==16.0.2", "pyyaml==3.11"],
+    install_requires=["docopt==0.6.2", "urllib3==1.17", "python-etcd==0.4.3", "pyzmq==16.0.2", "pyyaml==3.11"],
     tests_require=["Mock"],
     )

--- a/shared_setup.py
+++ b/shared_setup.py
@@ -57,5 +57,9 @@ setup(
         "pyyaml==3.11",
         "six==1.10.0",
         "urllib3==1.21.1"],
-    tests_require=["Mock"],
+    tests_require=[
+        "funcsigs==1.0.2",
+        "Mock==2.0.0",
+        "pbr==1.6",
+        "six==1.10.0"],
     )


### PR DESCRIPTION
I removed the dependencies which are in python-common.
I also removed the dependencies in the individual setup files which were also in the shared_setup.py file.

I then added downstream dependenices, which I found using the console output from the build server, and also by seeing what packages were present in the .eggs directory created when the repo is made.

I pinned the python packages to the versions on the build server.
For urllib3, two versions were originally installed. (1.17 and 1.21.1). I chose to pin to the most recent version.

I've spun up a deployment including these changes using chef, and it build correctly.