### PR TITLE
pin with right version of urllib3

### DIFF
--- a/fvtest_setup.py
+++ b/fvtest_setup.py
@@ -17,5 +17,8 @@ setup(
     name='clearwater-etcd-tests',
     version='1.0',
     test_suite='metaswitch.clearwater.etcd_tests',
-    tests_require=["urllib3==1.17", "python-etcd"],
+    tests_require=[
+        "dnspython==1.15.0",
+        "python-etcd==0.4.3",
+        "urllib3==1.21.1"],
     )

--- a/plugins_setup.py
+++ b/plugins_setup.py
@@ -18,10 +18,18 @@ setup(
     version='1.0',
     namespace_packages = ['metaswitch'],
     packages=['metaswitch', 'metaswitch.clearwater', 'metaswitch.clearwater.plugin_tests','clearwater_etcd_plugins','clearwater_etcd_plugins.chronos', 'clearwater_etcd_plugins.clearwater_memcached', 'clearwater_etcd_plugins.clearwater_config_manager', 'clearwater_etcd_plugins.clearwater_queue_manager', 'clearwater_etcd_plugins.clearwater_cassandra'],
-    package_dir={'':'src'},  
+    package_dir={'':'src'},
     package_data={
         '': ['*.eml'],
         },
     test_suite='metaswitch.clearwater.plugin_tests',
-    tests_require=["pyzmq==16.0.2", "metaswitchcommon", "py2-ipaddress==3.4.1", "pbr==1.6", "Mock", "pyyaml==3.11"],
+    tests_require=[
+        "funcsigs==1.0.2",
+        "metaswitchcommon",
+        "Mock==2.0.0",
+        "pbr==1.6",
+        "pyyaml==3.11",
+        "pyzmq==16.0.2",
+        "py2-ipaddress==3.4.1",
+        "six==1.10.0"],
     )


### PR DESCRIPTION
Not getting reviewed - since this is the equivalent of another reviewed request: https://github.com/Metaswitch/clearwater-etcd/pull/447/files.

The only additional change is pinning urllib3 to 1.21.1, not 1.21.2.
