### PR TITLE
Support Consul back-end for Cluster Manager

### DIFF
--- a/cluster_mgr_setup.py
+++ b/cluster_mgr_setup.py
@@ -25,7 +25,8 @@ setup(
     test_suite='metaswitch.clearwater.cluster_manager.test',
     install_requires=[
         "clearwater_etcd_shared",
-        "metaswitchcommon"],
+        "metaswitchcommon",
+        "python-consul==0.7.0"],
     tests_require=[
         "funcsigs==1.0.2",
         "Mock==2.0.0",

--- a/debian/control
+++ b/debian/control
@@ -11,12 +11,12 @@ Homepage: http://projectclearwater.org/
 
 Package: clearwater-etcd
 Architecture: all
-Depends: python-pip, clearwater-infrastructure, clearwater-monit
+Depends: python-pip
 Description: etcd configured for Clearwater
 
 Package: clearwater-cluster-manager
 Architecture: all
-Depends: python-pip, python-virtualenv, clearwater-etcd, clearwater-monit
+Depends: python-pip, python-virtualenv, clearwater-etcd
 Description: Cluster manager for Clearwater
 
 Package: clearwater-queue-manager

--- a/src/metaswitch/clearwater/cluster_manager/consul_synchronizer
+++ b/src/metaswitch/clearwater/cluster_manager/consul_synchronizer
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+import json
+
+import constants
+from .synchronization_fsm import SyncFSM
+from metaswitch.clearwater.etcd_shared.common_consul_synchronizer import CommonConsulSynchronizer
+from .cluster_state import ClusterInfo
+import logging
+
+_log = logging.getLogger(__name__)
+
+
+class ConsulSynchronizer(CommonConsulSynchronizer):
+    def __init__(self, plugin, ip, db_ip=None, force_leave=False):
+        super(ConsulSynchronizer, self).__init__(plugin, ip, db_ip)
+        self._fsm = SyncFSM(self._plugin, self._ip)
+        self._leaving_requested = False
+        self.force_leave = force_leave
+
+    def key(self):
+        return self._plugin.key()
+
+    def is_running(self):
+        return self._fsm.is_running()
+
+    def default_value(self):
+        return "{}"
+
+    def main(self):
+        # Continue looping while the FSM is running.
+        while self._fsm.is_running():
+            # This blocks on changes to the cluster in Consul.
+            _log.debug("Waiting for state change from Consul")
+            db_value = self.update_from_db()
+            if self._terminate_flag:
+                break
+            if db_value is not None:
+                _log.info("Got new state %s from Consul" % db_value)
+                cluster_info = ClusterInfo(db_value)
+
+                # This node can only leave the cluster if the cluster is in a
+                # stable state. Also check that we've both requested to leave
+                # and we're not already leaving (there's a race condition where
+                # the requested flag can only be cleared after updating Consul, but
+                # updating Consul triggers this function to be called).
+                # If necessary, set this node to WAITING_TO_LEAVE. Otherwise, kick
+                # the FSM.
+                if (self._leaving_requested and
+                    cluster_info.local_state(self._ip) != constants.WAITING_TO_LEAVE and
+                    cluster_info.can_leave(self.force_leave)):
+                    _log.info("Cluster is in a stable state, so leaving the cluster now")
+                    new_state = constants.WAITING_TO_LEAVE
+                else:
+                    new_state = self._fsm.next(cluster_info.local_state(self._ip),
+                                               cluster_info.cluster_state,
+                                               cluster_info.view)
+
+                # If we have a new state, try and write it to Consul.
+                if new_state is not None:
+                    self.write_to_db(cluster_info, new_state)
+                else:
+                    _log.debug("No state change")
+            else:
+                _log.warning("read_from_db returned None, " +
+                             "indicating a failure to get data from Consul")
+
+        _log.info("Quitting FSM")
+        self._fsm.quit()
+
+    # This node has been asked to leave the cluster. Check if the cluster is in
+    # a stable state, in which case we can leave. Otherwise, set a flag and
+    # leave at the next available opportunity.
+    def leave_cluster(self):
+        _log.info("Trying to leave the cluster - plugin %s" %
+                  self._plugin.__class__.__name__)
+
+        if not self._plugin.should_be_in_cluster():
+            _log.info("No need to leave remote cluster - just exit")
+            self._terminate_flag = True
+            return
+
+        db_result, idx = self.read_from_db(wait=False)
+        cluster_info = ClusterInfo(db_result)
+
+        self._leaving_requested = True
+        if cluster_info.can_leave(self.force_leave):
+            _log.info("Cluster is in a stable state, so leaving the cluster immediately")
+            self.write_to_db(cluster_info, constants.WAITING_TO_LEAVE)
+        else:
+            _log.info("Can't leave the cluster immediately - " +
+                      "will do so when the cluster next stabilises")
+
+    def mark_node_failed(self):
+        if not self._plugin.should_be_in_cluster():
+            _log.debug("No need to mark failure in remote cluster - doing nothing")
+            # We're just monitoring this cluster, not in it, so leaving is a
+            # no-op
+            return
+
+        db_result, idx = self.read_from_db(wait=False)
+        if db_result is not None:
+            _log.warning("Got result of None from read_from_db")
+        cluster_info = ClusterInfo(db_result)
+
+        self.write_to_db(cluster_info, constants.ERROR)
+
+    # Write the new cluster view to Consul. We may be expecting to create the key
+    # for the first time.
+    def write_to_db(self, cluster_info, new_state, with_index=None):
+        index = with_index or self._index or 0
+        cluster_view = cluster_info.view.copy()
+
+        # Update the cluster view based on new state information. If new_state
+        # is a string then it refers to the new state of the local node.
+        # Otherwise, it is an overall picture of the new cluster.
+        if new_state == constants.DELETE_ME:
+            del cluster_view[self._ip]
+        elif isinstance(new_state, str):
+            cluster_view[self._ip] = new_state
+        elif isinstance(new_state, dict):
+            cluster_view = new_state
+
+        _log.debug("Writing state %s into Consul" % cluster_view)
+        json_data = json.dumps(cluster_view)
+
+        try:
+            update_success = self._client.put(self.key(), json_data, cas=index)
+
+            # We may have just successfully set the local node to
+            # WAITING_TO_LEAVE, in which case we no longer need the leaving
+            # flag.
+            if new_state == constants.WAITING_TO_LEAVE:
+                self._leaving_requested = False
+
+            if not update_success:
+                _log.debug("Contention on Consul write - new_state is {}".format(new_state))
+                # Our Consul write failed because someone got there before us.
+
+                if isinstance(new_state, str):
+                    # We're just trying to update our own state, so it may be safe
+                    # to take the new state, update our own state in it, and retry.
+                    (db_result, idx) = self.read_from_db(wait=False)
+                    updated_cluster_info = ClusterInfo(db_result)
+
+                    # This isn't safe if someone else has changed our state for us,
+                    # or the overall deployment state has changed (in which case we
+                    # may want to change our state to something else, so check for
+                    # that.
+                    if ((new_state in [constants.ERROR, constants.DELETE_ME]) or
+                        ((updated_cluster_info.local_state(self._ip) ==
+                         cluster_info.local_state(self._ip)) and
+                        (updated_cluster_info.cluster_state ==
+                         cluster_info.cluster_state))):
+                        _log.debug("Retrying contended write with updated value")
+                        self.write_to_db(updated_cluster_info,
+                                           new_state,
+                                           cas=idx)
+        except Exception as e:
+            # Catch-all error handler (for invalid requests, timeouts, etc -
+            # unset our state and start over.
+            _log.error("{} caught {!r} when trying to write {} with index {}"
+                       " - pause before retrying"
+                       .format(self._ip, e, json_data, self._index))
+            # Setting last_cluster_view to None means that the next successful
+            # read from Consul will trigger the state machine, which will mean
+            # that any necessary work/state changes get retried.
+            self._last_value, self._last_index = None, None
+            # Sleep briefly to avoid hammering a failed server
+            self.pause()

--- a/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
@@ -162,7 +162,7 @@ class ConsulSynchronizer(CommonConsulSynchronizer):
                         _log.debug("Retrying contended write with updated value")
                         self.write_to_db(updated_cluster_info,
                                            new_state,
-                                           cas=idx)
+                                           with_index=idx)
         except Exception as e:
             # Catch-all error handler (for invalid requests, timeouts, etc -
             # unset our state and start over.

--- a/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
@@ -19,8 +19,8 @@ _log = logging.getLogger(__name__)
 
 
 class ConsulSynchronizer(CommonConsulSynchronizer):
-    def __init__(self, plugin, ip, db_ip=None, force_leave=False):
-        super(ConsulSynchronizer, self).__init__(plugin, ip, db_ip)
+    def __init__(self, plugin, ip, force_leave=False):
+        super(ConsulSynchronizer, self).__init__(plugin, ip)
         self._fsm = SyncFSM(self._plugin, self._ip)
         self._leaving_requested = False
         self.force_leave = force_leave

--- a/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
@@ -19,6 +19,10 @@ _log = logging.getLogger(__name__)
 
 
 class ConsulSynchronizer(CommonConsulSynchronizer):
+    """
+    Cluster manager synchroniser for the Consul back-end.
+    """
+
     def __init__(self, plugin, ip, db_ip=None, force_leave=False):
         super(ConsulSynchronizer, self).__init__(plugin, ip, db_ip)
         self._fsm = SyncFSM(self._plugin, self._ip)

--- a/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) Metaswitch Networks 2015
+# Copyright (C) Metaswitch Networks 2017
 # If license terms are provided to you in a COPYING file in the root directory
 # of the source code repository by which you are accessing this code, then
 # the license outlined in that COPYING file applies to your use.

--- a/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
@@ -19,8 +19,8 @@ _log = logging.getLogger(__name__)
 
 
 class ConsulSynchronizer(CommonConsulSynchronizer):
-    def __init__(self, plugin, ip, force_leave=False):
-        super(ConsulSynchronizer, self).__init__(plugin, ip)
+    def __init__(self, plugin, ip, db_ip=None, force_leave=False):
+        super(ConsulSynchronizer, self).__init__(plugin, ip, db_ip)
         self._fsm = SyncFSM(self._plugin, self._ip)
         self._leaving_requested = False
         self.force_leave = force_leave

--- a/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
+++ b/src/metaswitch/clearwater/cluster_manager/consul_synchronizer.py
@@ -28,9 +28,6 @@ class ConsulSynchronizer(CommonConsulSynchronizer):
     def key(self):
         return self._plugin.key()
 
-    def is_running(self):
-        return self._fsm.is_running()
-
     def default_value(self):
         return "{}"
 

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -10,8 +10,8 @@
 """Clearwater Cluster Manager
 
 Usage:
-  main.py --mgmt-local-ip=IP --sig-local-ip=IP --local-site=NAME --uuid=UUID (--etcd-key=KEY | --db-key=KEY) (--etcd-cluster-key=CLUSTER_KEY | --db-cluster-key=CLUSTER_KEY)
-          [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
+  main.py --mgmt-local-ip=IP --local-site=NAME --uuid=UUID (--etcd-key=KEY | --db-key=KEY) (--etcd-cluster-key=CLUSTER_KEY | --db-cluster-key=CLUSTER_KEY)
+          [--sig-local-ip=IP] [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
           [--log-directory=DIR] [--pidfile=FILE] [--cluster-manager-enabled=Y/N] [--etcd | --consul]
 
 Options:

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -11,7 +11,7 @@
 
 Usage:
   main.py --mgmt-local-ip=IP --sig-local-ip=IP --local-site=NAME --uuid=UUID (--etcd-key=KEY | --db-key=KEY) (--etcd-cluster-key=CLUSTER_KEY | --db-cluster-key=CLUSTER_KEY)
-          [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
+          [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--cassandra_container_id=ID] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
           [--log-directory=DIR] [--pidfile=FILE] [--cluster-manager-enabled=Y/N] [--etcd | --consul]
 
 Options:
@@ -26,6 +26,7 @@ Options:
   --db-cluster-key=CLUSTER_KEY   Back-end database key (used in the data store clusters)
   --remote-site=NAME             Name of remote site
   --remote-cassandra-seeds=IPs   Comma separated list of at least one IP address from each remote Cassandra site
+  --cassandra-container-id=ID    When containerised, the ID of the local Cassandra container
   --signaling-namespace=NAME     Name of the signaling namespace
   --foreground                   Don't daemonise
   --log-level=LVL                Level to log at, 0-4 [default: 3]
@@ -95,6 +96,7 @@ def main(args):
         remote_cassandra_seeds = remote_cassandra_seeds.split(',')
     else:
         remote_cassandra_seeds = []
+    cassandra_container_id = arguments.get('--cassandra-container-id')
     signaling_namespace = arguments.get('--signaling-namespace')
     local_uuid = UUID(arguments['--uuid'])
     etcd_key = arguments.get('--etcd-key') or arguments.get('--db-key')
@@ -164,7 +166,8 @@ def main(args):
                                                signaling_namespace=signaling_namespace,
                                                uuid=local_uuid,
                                                etcd_key=etcd_key,
-                                               etcd_cluster_key=etcd_cluster_key))
+                                               etcd_cluster_key=etcd_cluster_key,
+                                               cassandra_container_id=cassandra_container_id))
     plugins.sort(key=lambda x: x.key())
     plugins_to_use = []
     files = []

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -10,8 +10,8 @@
 """Clearwater Cluster Manager
 
 Usage:
-  main.py --mgmt-local-ip=IP --local-site=NAME --uuid=UUID (--etcd-key=KEY | --db-key=KEY) (--etcd-cluster-key=CLUSTER_KEY | --db-cluster-key=CLUSTER_KEY)
-          [--sig-local-ip=IP] [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
+  main.py --mgmt-local-ip=IP --sig-local-ip=IP --local-site=NAME --uuid=UUID (--etcd-key=KEY | --db-key=KEY) (--etcd-cluster-key=CLUSTER_KEY | --db-cluster-key=CLUSTER_KEY)
+          [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
           [--log-directory=DIR] [--pidfile=FILE] [--cluster-manager-enabled=Y/N] [--etcd | --consul]
 
 Options:

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -183,7 +183,7 @@ def main(args):
             if backend == "etcd":
                 syncer = EtcdSynchronizer(plugin, sig_ip, etcd_ip=mgmt_ip)
             else:
-                syncer = ConsulSynchronizer(plugin, mgmt_ip)
+                syncer = ConsulSynchronizer(plugin, sig_ip, db_ip=mgmt_ip)
 
             syncer.start_thread()
 

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -11,7 +11,7 @@
 
 Usage:
   main.py --mgmt-local-ip=IP --sig-local-ip=IP --local-site=NAME --uuid=UUID (--etcd-key=KEY | --db-key=KEY) (--etcd-cluster-key=CLUSTER_KEY | --db-cluster-key=CLUSTER_KEY)
-          [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--cassandra_container_id=ID] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
+          [--remote-site=NAME] [--remote-cassandra-seeds=IPs] [--cassandra-container-id=ID] [--signaling-namespace=NAME] [--foreground] [--log-level=LVL]
           [--log-directory=DIR] [--pidfile=FILE] [--cluster-manager-enabled=Y/N] [--etcd | --consul]
 
 Options:

--- a/src/metaswitch/clearwater/cluster_manager/plugin_base.py
+++ b/src/metaswitch/clearwater/cluster_manager/plugin_base.py
@@ -11,7 +11,7 @@ import collections
 
 PluginParams = collections.namedtuple(
                  'PluginParams',
-                 ['ip', 'mgmt_ip', 'local_site', 'remote_site', 'remote_cassandra_seeds', 'signaling_namespace', 'uuid', 'etcd_key', 'etcd_cluster_key'])
+                 ['ip', 'mgmt_ip', 'local_site', 'remote_site', 'remote_cassandra_seeds', 'signaling_namespace', 'uuid', 'etcd_key', 'etcd_cluster_key', 'cassandra_container_id'])
 
 
 class SynchroniserPluginBase(object): # pragma: no cover

--- a/src/metaswitch/clearwater/cluster_manager/test/test_base.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_base.py
@@ -13,8 +13,8 @@ from metaswitch.clearwater.etcd_shared.test.mock_python_etcd import MockEtcdClie
 from metaswitch.clearwater.cluster_manager.synchronization_fsm import SyncFSM
 from metaswitch.clearwater.cluster_manager.etcd_synchronizer import \
     EtcdSynchronizer
-from metaswitch.clearwater.etcd_shared.common_etcd_synchronizer import \
-    CommonEtcdSynchronizer
+from metaswitch.clearwater.etcd_shared.common_synchronizer import \
+    CommonSynchronizer
 from .dummy_plugin import DummyPlugin
 from time import sleep
 import json
@@ -26,9 +26,9 @@ alarms_patch = patch("metaswitch.clearwater.cluster_manager.alarms.alarm_manager
 class BaseClusterTest(unittest.TestCase):
     def setUp(self):
         SyncFSM.DELAY = 0.1
-        CommonEtcdSynchronizer.PAUSE_BEFORE_RETRY_ON_EXCEPTION = 0
-        CommonEtcdSynchronizer.PAUSE_BEFORE_RETRY_ON_MISSING_KEY = 0
-        CommonEtcdSynchronizer.TIMEOUT_ON_WATCH = 0
+        CommonSynchronizer.PAUSE_BEFORE_RETRY_ON_EXCEPTION = 0
+        CommonSynchronizer.PAUSE_BEFORE_RETRY_ON_MISSING_KEY = 0
+        CommonSynchronizer.TIMEOUT_ON_WATCH = 0
         MockEtcdClient.clear()
         alarms_patch.start()
         self.syncs = []

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2016
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+import unittest
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import MockConsulClient
+from metaswitch.clearwater.cluster_manager.synchronization_fsm import SyncFSM
+from metaswitch.clearwater.cluster_manager.consul_synchronizer import \
+    ConsulSynchronizer
+from metaswitch.clearwater.etcd_shared.common_synchronizer import \
+    CommonSynchronizer
+from .dummy_plugin import DummyPlugin
+from time import sleep
+import json
+# from etcd import EtcdKeyError
+from mock import patch
+
+alarms_patch = patch("metaswitch.clearwater.cluster_manager.alarms.alarm_manager")
+
+class BaseConsulBackedClusterTest(unittest.TestCase):
+    def setUp(self):
+        SyncFSM.DELAY = 0.1
+        CommonSynchronizer.PAUSE_BEFORE_RETRY_ON_EXCEPTION = 0
+        CommonSynchronizer.PAUSE_BEFORE_RETRY_ON_MISSING_KEY = 0
+        CommonSynchronizer.TIMEOUT_ON_WATCH = 0
+        MockConsulClient.clear()
+        alarms_patch.start()
+        self.syncs = []
+
+    def wait_for_all_normal(self, client, required_number=-1, tries=20):
+        for i in range(tries):
+            value = None
+            try:
+                (_, value) = client.get_noexcept("test")
+                end = json.loads(value.get("Value"))
+                if all([v == "normal" for v in end.itervalues()]) and \
+                   (required_number == -1 or len(end) == required_number):
+                    return
+            # except EtcdKeyError:
+            #     pass
+            except ValueError:
+                print "Got bad JSON '{}'".format(value)
+            sleep(0.1)
+
+    def make_and_start_synchronizers(self, num, klass=DummyPlugin):
+        ips = ["10.0.0.%s" % d for d in range(num)]
+        self.syncs = [ConsulSynchronizer(klass(ip), ip) for ip in ips]
+        for s in self.syncs:
+            s.start_thread()
+        sleep(1) # Allow cluster to stabilise
+
+    def close_synchronizers(self):
+        for s in self.syncs:
+            s.terminate()

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul_invalid_state.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul_invalid_state.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+from mock import patch
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import ConsulFactory
+import json
+from .test_consul import BaseConsulBackedClusterTest
+from time import sleep
+
+class TestInvalidState(BaseConsulBackedClusterTest):
+
+    def tearDown(self):
+        self.close_synchronizers()
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_invalid_state(self):
+        """Force an invalid state, and check that the clients don't try to
+        change it"""
+        client = ConsulFactory()
+        invalid_state= {"10.0.0.1": "joining",
+                        "10.0.0.2": "error",
+                        "10.0.2.1": "leaving"}
+        client.kv.put("test", json.dumps(invalid_state))
+        self.make_and_start_synchronizers(3)
+        client2 = self.syncs[0]._client
+        sleep(0.5)
+
+        (_, resp) = client2.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual(end, invalid_state)

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul_new_cluster.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul_new_cluster.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+import unittest
+from mock import patch
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import ConsulFactory, SlowMockConsulClient
+import json
+import os
+from .test_consul import BaseConsulBackedClusterTest
+
+
+class TestNewCluster(BaseConsulBackedClusterTest):
+
+    def tearDown(self):
+        self.close_synchronizers()
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_new_cluster(self):
+        """Create a new 3-node cluster and check that they all end up
+        in NORMAL state"""
+        self.make_and_start_synchronizers(3)
+        mock_client = self.syncs[0]._client
+        self.wait_for_all_normal(mock_client, required_number=3)
+
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.0"))
+        self.assertEqual("normal", end.get("10.0.0.1"))
+        self.assertEqual("normal", end.get("10.0.0.2"))
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_large_new_cluster(self):
+        """Create a new 30-node cluster and check that they all end up
+        in NORMAL state"""
+        self.make_and_start_synchronizers(30)
+        mock_client = self.syncs[0]._client
+        self.wait_for_all_normal(mock_client, required_number=30, tries=300)
+
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.3"))
+        self.assertEqual("normal", end.get("10.0.0.19"))
+        self.assertEqual("normal", end.get("10.0.0.29"))
+
+    @unittest.skipIf(os.environ.get("ETCD_IP"),
+                     "Relies on in-memory etcd implementation")
+    @unittest.skipUnless(os.environ.get("SLOW"), "SLOW=T not set")
+    @patch("consul.Consul", new=SlowMockConsulClient)
+    def test_large_new_cluster_with_delays(self):
+        """Create a new 30-node cluster and check that they all end up
+        in NORMAL state, even if etcd puts have a random delay that causes
+        contention and retries"""
+        self.make_and_start_synchronizers(30)
+        mock_client = self.syncs[0]._client
+        self.wait_for_all_normal(mock_client, required_number=30, tries=300)
+
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.3"))
+        self.assertEqual("normal", end.get("10.0.0.19"))
+        self.assertEqual("normal", end.get("10.0.0.29"))

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul_node_failure.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul_node_failure.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+from mock import patch
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import ConsulFactory
+from metaswitch.clearwater.cluster_manager.consul_synchronizer \
+    import ConsulSynchronizer
+from metaswitch.clearwater.cluster_manager.null_plugin import NullPlugin
+from .dummy_plugin import DummyPlugin
+from .fail_partway_through_plugin import FailPlugin
+from time import sleep
+import json
+from .test_consul import BaseConsulBackedClusterTest
+
+
+class TestNodeFailure(BaseConsulBackedClusterTest):
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_failure(self):
+
+        # Create synchronisers, using a FailPlugin for one which will crash and
+        # not complete (simulating a failed node)
+        sync1 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.1')
+        sync2 = ConsulSynchronizer(FailPlugin(None), '10.0.0.2')
+        sync3 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.3')
+        mock_client = sync1._client
+        for s in [sync1, sync2, sync3]:
+            s.start_thread()
+
+        # After a few seconds, the scale-up will still not have completed
+        sleep(3)
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertNotEqual("normal", end.get("10.0.0.1"))
+        self.assertNotEqual("normal", end.get("10.0.0.2"))
+        self.assertNotEqual("normal", end.get("10.0.0.3"))
+
+        # Start a synchroniser to take 10.0.0.2's place
+        sync2.terminate()
+        error_syncer = ConsulSynchronizer(NullPlugin('/test'),
+                                        '10.0.0.2',
+                                        force_leave=True)
+        error_syncer.mark_node_failed()
+        error_syncer.leave_cluster()
+        error_syncer.start_thread()
+
+        # 10.0.0.2 will be removed from the cluster, and the cluster will
+        # stabilise
+        self.wait_for_all_normal(mock_client, required_number=2, tries=50)
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.1"))
+        self.assertEqual("normal", end.get("10.0.0.3"))
+        self.assertEqual(None, end.get("10.0.0.2"))
+        for s in [sync1, sync3, error_syncer]:
+            s.terminate()

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul_resilience.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul_resilience.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+import unittest
+from mock import patch
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import ExceptionMockConsulClient
+import json
+from .test_consul import BaseConsulBackedClusterTest
+import os
+
+
+class TestResilience(BaseConsulBackedClusterTest):
+
+    @unittest.skipIf(os.environ.get("ETCD_IP"),
+                     "Relies on in-memory etcd implementation")
+    @patch("consul.Consul", new=ExceptionMockConsulClient)
+    def test_resilience_to_exceptions(self):
+        self.make_and_start_synchronizers(15)
+        mock_client = self.syncs[0]._client
+
+        # Check that the cluster stabilizes, even though etcd is throwing
+        # exceptions 50% of the time
+        self.wait_for_all_normal(mock_client, required_number=15, tries=300)
+
+        (_, resp) = mock_client.get_noexcept("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.3"))
+        self.assertEqual("normal", end.get("10.0.0.14"))
+        self.close_synchronizers()

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul_scale_down.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul_scale_down.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+from mock import patch
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import ConsulFactory
+from metaswitch.clearwater.cluster_manager.consul_synchronizer \
+    import ConsulSynchronizer
+from .dummy_plugin import DummyPlugin
+import json
+from .test_consul import BaseConsulBackedClusterTest
+from time import sleep
+
+
+class TestScaleDown(BaseConsulBackedClusterTest):
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_scale_down(self):
+        # Start with a stable cluster of four nodes
+        syncs = [ConsulSynchronizer(DummyPlugin(None), ip) for ip in
+                 ['10.0.1.1',
+                  '10.0.1.2',
+                  '10.0.1.3',
+                  '10.0.1.4',
+                  ]]
+        mock_client = syncs[0]._client
+        mock_client.put("test", json.dumps({"10.0.1.1": "normal",
+                                               "10.0.1.2": "normal",
+                                               "10.0.1.3": "normal",
+                                               "10.0.1.4": "normal",
+                                               }))
+        for s in syncs:
+            s.start_thread()
+
+        # Allow the cluster to stabilise, then make the second and fourth nodes leave
+        sleep(1)
+        syncs[1].leave_cluster()
+        syncs[3].leave_cluster()
+
+        self.wait_for_all_normal(mock_client, required_number=2, tries=50)
+
+        # Check that it's left and the cluster is stable
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.1.1"))
+        self.assertEqual("normal", end.get("10.0.1.3"))
+        self.assertEqual(None, end.get("10.0.1.2"))
+        self.assertEqual(None, end.get("10.0.1.4"))
+
+        for s in syncs:
+            s.terminate()

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul_scale_up.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul_scale_up.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+from mock import patch
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import ConsulFactory
+from metaswitch.clearwater.cluster_manager.consul_synchronizer \
+    import ConsulSynchronizer
+from .dummy_plugin import DummyPlugin
+import json
+from .test_consul import BaseConsulBackedClusterTest
+
+
+class TestConsulScaleUp(BaseConsulBackedClusterTest):
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_scale_up(self):
+        # Create an existing cluster of two nodes, and a third new node
+        sync1 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.1')
+        sync2 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.2')
+        sync3 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.3')
+        mock_client = sync1._client
+        mock_client.put("test", json.dumps({"10.0.0.1": "normal",
+                                            "10.0.0.2": "normal"}))
+        for s in [sync1, sync2, sync3]:
+            s.start_thread()
+
+        # Check that the third node joins the cluster
+        self.wait_for_all_normal(mock_client, required_number=3)
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.3"))
+        for s in [sync1, sync2, sync3]:
+            s.terminate()
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_two_new_nodes(self):
+        # Create an existing cluster of two nodes, and a third and fourth new
+        # node at the same time
+        sync1 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.1')
+        sync2 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.2')
+        sync3 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.3')
+        sync4 = ConsulSynchronizer(DummyPlugin(None), '10.0.0.4')
+        mock_client = sync1._client
+        mock_client.put("test", json.dumps({"10.0.0.1": "normal",
+                                            "10.0.0.2": "normal"}))
+        for s in [sync1, sync2, sync3, sync4]:
+            s.start_thread()
+
+        # Check that the third and fourth nodes join the cluster
+        self.wait_for_all_normal(mock_client, required_number=4)
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.3"))
+        self.assertEqual("normal", end.get("10.0.0.4"))
+        for s in [sync1, sync2, sync3, sync4]:
+            s.terminate()

--- a/src/metaswitch/clearwater/cluster_manager/test/test_consul_watcher_plugin.py
+++ b/src/metaswitch/clearwater/cluster_manager/test/test_consul_watcher_plugin.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright (C) Metaswitch Networks 2015
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+from mock import patch
+from metaswitch.clearwater.etcd_shared.test.mock_python_consul import ConsulFactory
+import json
+from .test_consul import BaseConsulBackedClusterTest
+from .dummy_plugin import DummyWatcherPlugin
+from metaswitch.clearwater.cluster_manager.consul_synchronizer import \
+    ConsulSynchronizer
+from time import sleep
+
+class TestWatcherPlugin(BaseConsulBackedClusterTest):
+
+    def setUp(self):
+        BaseConsulBackedClusterTest.setUp(self)
+        self.watcher_ip = "10.1.1.1"
+        self.plugin = DummyWatcherPlugin(self.watcher_ip);
+
+    def tearDown(self):
+        self.close_synchronizers()
+
+    @patch("consul.Consul", new=ConsulFactory)
+    def test_watcher(self):
+        """Create a new 3-node cluster with one plugin not in the cluster and
+        check that the main three all end up in NORMAL state"""
+
+        e = ConsulSynchronizer(self.plugin, self.watcher_ip)
+        e.start_thread()
+
+        self.make_and_start_synchronizers(3)
+        mock_client = self.syncs[0]._client
+        self.wait_for_all_normal(mock_client, required_number=3)
+
+        # Pause for one second - the watcher plugin might be called just after
+        # all other nodes enter 'normal' state
+        sleep(1)
+        self.assertTrue(self.plugin.on_stable_cluster_called)
+
+        (_, resp) = mock_client.get("test")
+        end = json.loads(resp.get("Value"))
+        self.assertEqual("normal", end.get("10.0.0.0"))
+        self.assertEqual("normal", end.get("10.0.0.1"))
+        self.assertEqual("normal", end.get("10.0.0.2"))
+        self.assertEqual(None, end.get("10.1.1.1"))
+
+        e.terminate()
+
+    @patch("consul.Consul")
+    def test_leaving(self, client):
+        """Create a plugin not in the cluster and try to leave the cluster.
+        Nothing should be written to etcd."""
+        e = ConsulSynchronizer(self.plugin, self.watcher_ip)
+        e.start_thread()
+
+        e.leave_cluster()
+        e._client.put.assert_not_called()
+
+        e.terminate()
+
+    @patch("consul.Consul")
+    def test_mark_failed(self, client):
+        """Create a plugin not in the cluster and try to mark it as failed.
+        Nothing should be written to etcd."""
+        e = ConsulSynchronizer(self.plugin, self.watcher_ip)
+        e.start_thread()
+
+        e.mark_node_failed()
+        e._client.put.assert_not_called()
+
+        e.terminate()
+

--- a/src/metaswitch/clearwater/etcd_shared/common_consul_synchroniser.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_consul_synchroniser.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python
+
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+import consul
+# from threading import Thread
+from time import sleep
+# from functools import wraps
+import logging
+# import traceback
+# import os
+# import signal
+from metaswitch.common import utils
+from metaswitch.clearwater.etcd_shared.common_synchronizer import CommonSynchronizer
+
+_log = logging.getLogger(__name__)
+
+class CommonConsulSynchronizer(CommonSynchronizer):
+
+    def __init__(self, plugin, ip, db_ip=None):
+        super(CommonConsulSynchronizer, self).__init__(plugin)
+        self._ip = ip
+
+        self._client = consul.Consul(host=db_ip).kv
+
+    # Read the state of the cluster from Consul (optionally waiting for a
+    # changed state). Returns None if nothing could be read.
+    def read_from_db(self, wait=True):
+        result = None
+        wait_index = None
+
+        try:
+            (wait_index, result) = self._client.get(self.key(), consistency=True)
+            wait_index += 1
+
+            if wait:
+                # If the cluster view hasn't changed since we last saw it, then
+                # wait for it to change before doing anything else.
+                _log.info("Read value {} from Consul, "
+                          "comparing to last value {}".format(
+                              utils.safely_encode(result.get("Value")),
+                              utils.safely_encode(self._last_value)))
+
+                if result and result.get("Value") == self._last_value:
+                    _log.info("Watching for changes with {}".format(wait_index))
+
+                    while not self._terminate_flag and not self._abort_read and self.is_running():
+                        _log.debug("Started a new watch")
+                        try:
+                            (_, result) = self._client.get(self.key(),
+                                                           wait=self.TIMEOUT_ON_WATCH,
+                                                           index=wait_index,
+                                                           recurse=False)
+                            break
+                        except consul.Timeout as e:
+                            if "Read timed out" in e.message:
+                                # Timeouts after TIMEOUT_ON_WATCH seconds are expected, so
+                                # ignore them - unless we're terminating, we'll
+                                # stay in the while loop and try again
+                                pass
+                            else:
+                                raise
+
+                    _log.debug("Finished watching")
+
+                    # Return if we're terminating.
+                    if self._terminate_flag:
+                        return self.tuple_from_result(result)
+
+                if result == None:
+                    _log.info("Key {} doesn't exist in Consul yet".format(self.key()))
+                    # Use any value on disk first, but the default value if not found
+                    try:
+                        f = open(self._plugin.file(), 'r')
+                        value = f.read()  # pragma: no cover
+                    except:
+                        value = self.default_value()
+
+                    # Attempt to create new key in Consul.
+                    try:
+                        # The `cas` set to 0 will fail the write if it finds a
+                        # key already in Consul. This stops us overwriting a manually
+                        # uploaded file with the default template.
+                        self._client.put(self.key(), value, cas=0)
+                        return (value, None)
+                    except:  # pragma: no cover
+                        _log.debug("Failed to create new key in the Consul store")
+                        # Sleep briefly to avoid hammering a non-existent key
+                        sleep(self.PAUSE_BEFORE_RETRY_ON_MISSING_KEY)
+                        # Return 'None' so that plugins do not write config to disk
+                        # that does not exist in the Consul store, leaving us out of sync
+                        return (None, None)
+
+        except Exception as e:
+            # Catch-all error handler (for invalid requests, timeouts, etc -
+            # start over.
+            _log.error("{} caught {!r} when trying to read with index {}"
+                       " - pause before retry".
+                       format(self._ip, e, wait_index))
+            # Sleep briefly to avoid hammering a failed server
+            self.pause()
+            # The main loop (which reads from Consul in a loop) should call this
+            # function again after we return, causing the read to be retried.
+
+        return self.tuple_from_result(result)
+
+    # Calls read_from_db, and updates internal state to track the previously
+    # seen value.
+    #
+    # The difference is:
+    # - calling read_from_db twice will return the same value
+    # - calling read_from_db twice will block on the second call until the
+    # value changes
+    #
+    # Only the main thread should call update_from_db to avoid race conditions
+    # or missed reads.
+    def update_from_db(self):
+        self._last_value, self._index = self.read_from_db(wait=True)
+        return self._last_value
+
+    def tuple_from_result(self, result):
+        if result is None:
+            return (None, None)
+        elif self._abort_read is True:
+            return (self._last_value, self._index)
+        else:
+            return (result.get("Value"), result.get("ModifyIndex"))

--- a/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
@@ -8,13 +8,8 @@
 # Metaswitch Networks in a separate written agreement.
 
 import consul
-# from threading import Thread
 from time import sleep
-# from functools import wraps
 import logging
-# import traceback
-# import os
-# import signal
 from metaswitch.common import utils
 from metaswitch.clearwater.etcd_shared.common_synchronizer import CommonSynchronizer
 

--- a/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
@@ -44,22 +44,10 @@ class CommonConsulSynchronizer(CommonSynchronizer):
                 if result and result.get("Value") == self._last_value:
                     _log.info("Watching for changes with {}".format(wait_index))
 
-                    while not self._terminate_flag and not self._abort_read and self.is_running():
-                        _log.debug("Started a new watch")
-                        try:
-                            (_, result) = self._client.get(self.key(),
-                                                           wait=self.TIMEOUT_ON_WATCH,
-                                                           index=wait_index,
-                                                           recurse=False)
-                            break
-                        except consul.Timeout as e:
-                            if "Read timed out" in e.message:
-                                # Timeouts after TIMEOUT_ON_WATCH seconds are expected, so
-                                # ignore them - unless we're terminating, we'll
-                                # stay in the while loop and try again
-                                pass
-                            else:
-                                raise
+                    (_, result) = self._client.get(self.key(),
+                                                   wait=self.TIMEOUT_ON_WATCH,
+                                                   index=wait_index,
+                                                   recurse=False)
 
                     _log.debug("Finished watching")
 
@@ -121,7 +109,8 @@ class CommonConsulSynchronizer(CommonSynchronizer):
     def tuple_from_result(self, result):
         if result is None:
             return (None, None)
-        elif self._abort_read is True:
-            return (self._last_value, self._index)
+        # FIXME: re-enable this to support Consul for Queue Manger
+        # elif self._abort_read is True:
+        #     return (self._last_value, self._index)
         else:
             return (result.get("Value"), result.get("ModifyIndex"))

--- a/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
@@ -31,6 +31,8 @@ class CommonConsulSynchronizer(CommonSynchronizer):
 
         try:
             (wait_index, result) = self._client.get(self.key(), consistency=True)
+            # FIXME: is this a string???
+            wait_index=int(wait_index)
             wait_index += 1
 
             if wait:

--- a/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
@@ -22,11 +22,11 @@ _log = logging.getLogger(__name__)
 
 class CommonConsulSynchronizer(CommonSynchronizer):
 
-    def __init__(self, plugin, ip, db_ip=None):
+    def __init__(self, plugin, ip):
         super(CommonConsulSynchronizer, self).__init__(plugin)
         self._ip = ip
 
-        self._client = consul.Consul(host=db_ip).kv
+        self._client = consul.Consul(host=ip).kv
 
     # Read the state of the cluster from Consul (optionally waiting for a
     # changed state). Returns None if nothing could be read.

--- a/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
@@ -22,11 +22,11 @@ _log = logging.getLogger(__name__)
 
 class CommonConsulSynchronizer(CommonSynchronizer):
 
-    def __init__(self, plugin, ip):
+    def __init__(self, plugin, ip, db_ip):
         super(CommonConsulSynchronizer, self).__init__(plugin)
         self._ip = ip
 
-        self._client = consul.Consul(host=ip).kv
+        self._client = consul.Consul(host=db_ip).kv
 
     # Read the state of the cluster from Consul (optionally waiting for a
     # changed state). Returns None if nothing could be read.
@@ -43,7 +43,7 @@ class CommonConsulSynchronizer(CommonSynchronizer):
                 # wait for it to change before doing anything else.
                 _log.info("Read value {} from Consul, "
                           "comparing to last value {}".format(
-                              utils.safely_encode(result.get("Value")),
+                              utils.safely_encode(str(result)),
                               utils.safely_encode(self._last_value)))
 
                 if result and result.get("Value") == self._last_value:

--- a/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_consul_synchronizer.py
@@ -16,6 +16,9 @@ from metaswitch.clearwater.etcd_shared.common_synchronizer import CommonSynchron
 _log = logging.getLogger(__name__)
 
 class CommonConsulSynchronizer(CommonSynchronizer):
+    """
+    Common synchroniser for the Consul back-end.
+    """
 
     def __init__(self, plugin, ip, db_ip):
         super(CommonConsulSynchronizer, self).__init__(plugin)
@@ -31,7 +34,6 @@ class CommonConsulSynchronizer(CommonSynchronizer):
 
         try:
             (wait_index, result) = self._client.get(self.key(), consistency=True)
-            # FIXME: is this a string???
             wait_index=int(wait_index)
             wait_index += 1
 

--- a/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
@@ -29,13 +29,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 import etcd
-# from threading import Thread
 from time import sleep
 from functools import wraps
 import logging
-# import traceback
-# import os
-# import signal
 from metaswitch.common import utils
 from metaswitch.clearwater.etcd_shared.common_synchronizer import CommonSynchronizer
 

--- a/src/metaswitch/clearwater/etcd_shared/common_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_synchronizer.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# import etcd
+from threading import Thread
+from time import sleep
+# from functools import wraps
+import logging
+import traceback
+import os
+import signal
+# from metaswitch.common import utils
+
+_log = logging.getLogger(__name__)
+
+
+class CommonSynchronizer(object):
+    PAUSE_BEFORE_RETRY_ON_EXCEPTION = 30
+    PAUSE_BEFORE_RETRY_ON_MISSING_KEY = 5
+    TIMEOUT_ON_WATCH = 5
+
+    def __init__(self, plugin):
+        self._plugin = plugin
+        self._index = None
+        self._last_value = None
+
+        # Set the terminate flag and the abort read flag to false initially
+        # The terminate flag controls whether the synchronizer as a whole
+        # should terminate, the abort flag ensures that any synchronizer
+        # threads controlled by a futures is shut down fully
+        self._terminate_flag = False
+        self._abort_read = False
+        self.thread = Thread(target=self.main_wrapper, name=self.thread_name())
+
+    def start_thread(self):
+        self.thread.daemon = True
+        self.thread.start()
+
+    def terminate(self):
+        self._terminate_flag = True
+        self.thread.join()
+
+    def pause(self):
+        sleep(self.PAUSE_BEFORE_RETRY_ON_EXCEPTION)
+
+    def main_wrapper(self):  # pragma: no cover
+        # This function should be the entry point when we start an
+        # EtcdSynchronizer thread. We use it to catch exceptions in main and
+        # restart the whole process; if we didn't do this the thread would be
+        # dead and we'd never notice.
+        try:
+            self.main()
+        except Exception:
+            # Log the exception and send a SIGTERM to this process. If the
+            # process needs to do anything before shutting down, it will have a
+            # handler for catching the SIGTERM.
+            _log.error(traceback.format_exc())
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    def main(self):
+        pass
+
+    def default_value(self):
+        return None
+
+    def is_running(self):
+        return True
+
+    def thread_name(self):
+        return self._plugin.__class__.__name__

--- a/src/metaswitch/clearwater/etcd_shared/common_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_synchronizer.py
@@ -7,15 +7,12 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-# import etcd
 from threading import Thread
 from time import sleep
-# from functools import wraps
 import logging
 import traceback
 import os
 import signal
-# from metaswitch.common import utils
 
 _log = logging.getLogger(__name__)
 
@@ -49,27 +46,27 @@ class CommonSynchronizer(object):
     def pause(self):
         sleep(self.PAUSE_BEFORE_RETRY_ON_EXCEPTION)
 
-    def main_wrapper(self):  # pragma: no cover
+    def main_wrapper(self):
         # This function should be the entry point when we start an
         # EtcdSynchronizer thread. We use it to catch exceptions in main and
         # restart the whole process; if we didn't do this the thread would be
         # dead and we'd never notice.
         try:
             self.main()
-        except Exception:
+        except Exception:  # pragma: no cover
             # Log the exception and send a SIGTERM to this process. If the
             # process needs to do anything before shutting down, it will have a
             # handler for catching the SIGTERM.
             _log.error(traceback.format_exc())
             os.kill(os.getpid(), signal.SIGTERM)
 
-    def main(self):
+    def main(self):  # pragma: no cover
         pass
 
-    def default_value(self):
+    def default_value(self):  # pragma: no cover
         return None
 
-    def is_running(self):
+    def is_running(self):  # pragma: no cover
         return True
 
     def thread_name(self):

--- a/src/metaswitch/clearwater/etcd_shared/test/mock_python_consul.py
+++ b/src/metaswitch/clearwater/etcd_shared/test/mock_python_consul.py
@@ -1,4 +1,4 @@
-# Copyright (C) Metaswitch Networks 2016
+# Copyright (C) Metaswitch Networks 2017
 # If license terms are provided to you in a COPYING file in the root directory
 # of the source code repository by which you are accessing this code, then
 # the license outlined in that COPYING file applies to your use.

--- a/src/metaswitch/clearwater/etcd_shared/test/mock_python_consul.py
+++ b/src/metaswitch/clearwater/etcd_shared/test/mock_python_consul.py
@@ -1,0 +1,197 @@
+# Copyright (C) Metaswitch Networks 2016
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+from threading import Condition
+import consul
+# from etcd import EtcdResult, Client, EtcdException, EtcdKeyError
+from consul import Timeout
+from random import random, choice
+from time import sleep
+import os
+
+allowed_key = 'test'
+global_data = None
+global_index = 0
+global_condvar = Condition()
+
+
+def ConsulFactory(*args, **kwargs):
+    """Factory method, returning a connection to a real etcd if we need one for
+    FV, or to an in-memory implementation for UT."""
+    if os.environ.get('ETCD_IP'):
+        return Client(host=os.environ.get('ETCD_IP'),
+                      port=int(os.environ.get('ETCD_PORT', 8500)))
+    else:
+        return MockConsulClient(None, None)
+
+
+class MockConsulClient(object):
+    def __init__(
+            self,
+            host='127.0.0.1',
+            port=8500,
+            token=None,
+            scheme='http',
+            consistency='default',
+            dc=None,
+            verify=True,
+            cert=None):
+        self.kv = MockConsulKv()
+
+    @classmethod
+    def clear(self):
+        MockConsulKv.clear()
+
+class MockConsulKv(object):
+    def __init__(self):
+        self._value = None
+
+    @classmethod
+    def clear(self):
+        global global_index
+        global global_data
+        global_condvar.acquire()
+        global_index = 0
+        global_data = None
+        global_condvar.release()
+
+    def fake_result(self, key):
+        return (global_index, {
+                "CreateIndex": 1,
+                "ModifyIndex": global_index,
+                "LockIndex": 1,
+                "Key": key,
+                "Flags": 0,
+                "Value": global_data,
+                "Session": "adf4238a-882b-9ddc-4a9d-5b6758e4159e"
+            })
+
+    def get(
+            self,
+            key,
+            index=None,
+            recurse=False,
+            wait=None,
+            token=None,
+            consistency=None,
+            keys=False,
+            separator=None,
+            dc=None):
+
+        with global_condvar:
+            if wait:
+                if global_index == 0:
+                    return (global_index, None)
+                if waitIndex > global_index:
+                    global_condvar.wait(0.1)
+                if waitIndex > global_index:
+                    raise Timeout
+            if global_data == None:
+                return (global_index, None)
+            ret = self.fake_result(key)
+        return ret
+
+    def put(
+            self,
+            key,
+            value,
+            cas=None,
+            flags=None,
+            acquire=None,
+            release=None,
+            token=None,
+            dc=None):
+
+        global global_index
+        global global_data
+        global_condvar.acquire()
+        if (cas != None) and (cas != global_index):
+            global_condvar.release()
+            return False
+        global_data = value
+        global_index += 1
+        global_condvar.notify_all()
+        global_condvar.release()
+
+        return True
+
+    def get_noexcept(self, *args, **kwargs):
+        """Method to allow the UT infrastructure to read the value, without
+        triggering an exception."""
+        return self.get(*args, **kwargs)
+
+class SlowMockConsulClient(MockConsulClient):
+    def __init__(
+            self,
+            host='127.0.0.1',
+            port=8500,
+            token=None,
+            scheme='http',
+            consistency='default',
+            dc=None,
+            verify=True,
+            cert=None):
+        self.kv = SlowMockConsulKv()
+
+
+class SlowMockConsulKv(MockConsulKv):
+    def put(
+            self,
+            key,
+            value,
+            cas=None,
+            flags=None,
+            acquire=None,
+            release=None,
+            token=None,
+            dc=None):
+        """Make writes take 0-200ms to discover race conditions"""
+        sleep(random()/5.0)
+        super(SlowMockEtcdClient, self).write(key,
+                                              value,
+                                              cas=cas,
+                                              flags=flags,
+                                              acquire=acquire,
+                                              release=release,
+                                              token=token,
+                                              dc=dc)
+
+    def get_noexcept(self, *args, **kwargs):
+        """Method to allow the UT infrastructure to read the value, without
+        triggering an exception."""
+        return super(SlowMockConsulKv, self).get(*args, **kwargs)
+
+
+class ExceptionMockConsulClient(MockConsulClient):
+    def __init__(
+            self,
+            host='127.0.0.1',
+            port=8500,
+            token=None,
+            scheme='http',
+            consistency='default',
+            dc=None,
+            verify=True,
+            cert=None):
+        self.kv = ExceptionMockConsulKv()
+
+
+class ExceptionMockConsulKv(MockConsulKv):
+    def get(self, *args, **kwargs):
+        if random() > 0.9:
+            raise consul.ConsulException("sample message")
+        return super(ExceptionMockConsulKv, self).get(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        if random() > 0.9:
+            raise consul.ConsulException("sample message")
+        return super(ExceptionMockConsulKv, self).put(*args, **kwargs)
+
+    def get_noexcept(self, *args, **kwargs):
+        """Method to allow the UT infrastructure to read the value, without
+        triggering an exception."""
+        return super(ExceptionMockConsulKv, self).get(*args, **kwargs)

--- a/src/metaswitch/clearwater/etcd_shared/test/mock_python_consul.py
+++ b/src/metaswitch/clearwater/etcd_shared/test/mock_python_consul.py
@@ -7,7 +7,6 @@
 
 from threading import Condition
 import consul
-# from etcd import EtcdResult, Client, EtcdException, EtcdKeyError
 from consul import Timeout
 from random import random, choice
 from time import sleep

--- a/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
@@ -45,7 +45,8 @@ class TestCassandraPlugin(unittest.TestCase):
                                               signaling_namespace='',
                                               uuid=uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),
                                               etcd_key='etcd_key',
-                                              etcd_cluster_key='etcd_cluster_key'))
+                                              etcd_cluster_key='etcd_cluster_key',
+                                              cassandra_container_id=None))
 
         # We expect this alarm to be called on creation of the plugin
         mock_get_alarm.assert_called_once_with('cluster-manager',
@@ -140,7 +141,7 @@ seed_provider:\n\
             [mock.call("/etc/cassandra/cassandra.yaml"),
              mock.call("/etc/clearwater/force_cassandra_yaml_refresh")]
 
-        # These calls cover restarting cassandra, and the commands called by 
+        # These calls cover restarting cassandra, and the commands called by
         # the plugin in wait_for_cassandra.
         run_command_call_list = \
             [mock.call("start-stop-daemon -K -p /var/run/cassandra/cassandra.pid -R TERM/30/KILL/5"),

--- a/src/metaswitch/clearwater/plugin_tests/test_chronos_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_chronos_plugin.py
@@ -48,7 +48,8 @@ class TestChronosPlugin(unittest.TestCase):
                                             signaling_namespace='',
                                             uuid=uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),
                                             etcd_key='etcd_key',
-                                            etcd_cluster_key='etcd_cluster_key'))
+                                            etcd_cluster_key='etcd_cluster_key',
+                                              cassandra_container_id=None,))
 
         # We expect this alarm to be called on creation of the plugin
         mock_get_alarm.assert_called_once_with('cluster-manager',

--- a/src/metaswitch/clearwater/plugin_tests/test_memcached_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_memcached_plugin.py
@@ -37,7 +37,8 @@ class TestMemcachedPlugin(unittest.TestCase):
                                               signaling_namespace='',
                                               uuid=uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),
                                               etcd_key='etcd_key',
-                                              etcd_cluster_key='etcd_cluster_key'))
+                                              etcd_cluster_key='etcd_cluster_key',
+                                              cassandra_container_id=None))
 
         # We expect this alarm to be called on creation of the plugin
         mock_get_alarm.assert_called_once_with('cluster-manager',
@@ -111,7 +112,8 @@ class TestMemcachedPlugin(unittest.TestCase):
                                               signaling_namespace='',
                                               uuid=uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),
                                               etcd_key='etcd_key',
-                                              etcd_cluster_key='etcd_cluster_key'))
+                                              etcd_cluster_key='etcd_cluster_key',
+                                              cassandra_container_id=None))
 
         # We expect this alarm to be called on creation of the plugin
         mock_get_alarm.assert_called_once_with('cluster-manager',
@@ -176,7 +178,8 @@ class TestMemcachedPlugin(unittest.TestCase):
                                                     signaling_namespace='',
                                                     uuid=uuid.UUID('92a674aa-a64b-4549-b150-596fd466923f'),
                                                     etcd_key='etcd_key',
-                                                    etcd_cluster_key='etcd_cluster_key'))
+                                                    etcd_cluster_key='etcd_cluster_key',
+                                                    cassandra_container_id=None))
 
         # Config writing is properly tested above, so run with simple cluster
         cluster_view = {"10.0.0.5": "normal"}


### PR DESCRIPTION
In the orchestration team, we're planning to use Cluster Manager to manage a cluster of (containerised) Cassandra nodes, using a [Consul](https://www.consul.io/api/kv.html) back-end (instead of etcd) - see https://github.com/Metaswitch/dudamel/blob/master/docs/dm_pooling.md#cassandra

This PR adds support for a Consul back-end to the Cluster Manger as a replacement for etcd.