### PR TITLE
[Reviewer: Sathiyan] Increase log level for alarms

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/alarms.py
+++ b/src/metaswitch/clearwater/cluster_manager/alarms.py
@@ -36,7 +36,7 @@ class TooLongAlarm(object):
         with self._condition:
             self._condition.wait(self._delay)
             if self._should_alarm:
-                _log.debug("Raising TOO_LONG_CLUSTERING alarm")
+                _log.info("Raising TOO_LONG_CLUSTERING alarm")
                 self._alarm.set()
 
     def trigger(self, thread_name="Alarm thread"):

--- a/src/metaswitch/clearwater/queue_manager/alarms.py
+++ b/src/metaswitch/clearwater/queue_manager/alarms.py
@@ -20,13 +20,13 @@ class QueueAlarm(object):
         self._name = name
 
     def clear(self):
-        _log.debug("Clearing %s alarm" % self._name)
+        _log.info("Clearing %s alarm" % self._name)
         self._alarm.clear()
 
     def minor(self):
-        _log.debug("Raising minor %s alarm" % self._name)
+        _log.info("Raising minor %s alarm" % self._name)
         self._alarm.set(MINOR)
 
     def critical(self):
-        _log.debug("Raising critical %s alarm" % self._name)
+        _log.info("Raising critical %s alarm" % self._name)
         self._alarm.set(CRITICAL)


### PR DESCRIPTION
This raises the alarms logs to INFO level. This matches how we log alarms in the other components, it's not spammy given it's only when the alarm is raised/cleared by the queue/cluster manager (not the alarm manager resending alarms), and it's useful information to always have in the logs.