### PR TITLE
[Reviewer: Richard] Delay starting the plugin threads

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -170,10 +170,10 @@ def main(args):
         # Don't start any threads as we don't want this box to cluster
         pdlogs.DO_NOT_CLUSTER.log()
     else:
+        # Load the plugins, but don't start them until we've installed the
+        # SIGTERM handler
         for plugin in plugins_to_use:
             syncer = EtcdSynchronizer(plugin, sig_ip, etcd_ip=mgmt_ip)
-            syncer.start_thread()
-
             synchronizers.append(syncer)
             threads.append(syncer.thread)
             _log.info("Loaded plugin %s" % plugin)
@@ -181,6 +181,10 @@ def main(args):
 
     install_sigquit_handler(synchronizers)
     utils.install_sigterm_handler(synchronizers)
+
+    # If we have any plugins, start their threads now
+    for syncer in synchronizers:
+        syncer.start_thread()
 
     while any([thread.isAlive() for thread in threads]):
         for thread in threads:

--- a/src/metaswitch/clearwater/cluster_manager/main.py
+++ b/src/metaswitch/clearwater/cluster_manager/main.py
@@ -171,7 +171,8 @@ def main(args):
         pdlogs.DO_NOT_CLUSTER.log()
     else:
         # Load the plugins, but don't start them until we've installed the
-        # SIGTERM handler
+        # SIGTERM handler, as that handler will gracefully shut down any
+        # remaining synchronizers on receiving a SIGTERM
         for plugin in plugins_to_use:
             syncer = EtcdSynchronizer(plugin, sig_ip, etcd_ip=mgmt_ip)
             synchronizers.append(syncer)
@@ -185,6 +186,7 @@ def main(args):
     # If we have any plugins, start their threads now
     for syncer in synchronizers:
         syncer.start_thread()
+        _log.info("Started thread for plugin %s" % syncer._plugin)
 
     while any([thread.isAlive() for thread in threads]):
         for thread in threads:

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -104,7 +104,8 @@ def main(args):
     alarm = ConfigAlarm(files)
 
     # Load the plugins, but don't start them until we've installed the SIGTERM
-    # handler
+    # handler, as that handler will gracefully shut down any running
+    # synchronizers on receiving a SIGTERM
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, alarm, etcd_key)
         synchronizers.append(syncer)
@@ -116,6 +117,7 @@ def main(args):
     # Now start the plugin threads
     for syncer in synchronizers:
         syncer.start_thread()
+        _log.info("Started thread for plugin %s" % syncer._plugin)
 
     while any([thr.isAlive() for thr in threads]):
         for thr in threads:

--- a/src/metaswitch/clearwater/config_manager/main.py
+++ b/src/metaswitch/clearwater/config_manager/main.py
@@ -103,15 +103,19 @@ def main(args):
     files = [p.file() for p in plugins]
     alarm = ConfigAlarm(files)
 
+    # Load the plugins, but don't start them until we've installed the SIGTERM
+    # handler
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, alarm, etcd_key)
-        syncer.start_thread()
-
         synchronizers.append(syncer)
         threads.append(syncer.thread)
         _log.info("Loaded plugin %s" % plugin)
 
     utils.install_sigterm_handler(synchronizers)
+
+    # Now start the plugin threads
+    for syncer in synchronizers:
+        syncer.start_thread()
 
     while any([thr.isAlive() for thr in threads]):
         for thr in threads:

--- a/src/metaswitch/clearwater/queue_manager/main.py
+++ b/src/metaswitch/clearwater/queue_manager/main.py
@@ -105,7 +105,8 @@ def main(args):
     threads = []
 
     # Load the plugins, but don't start them until we've installed the SIGTERM
-    # handler
+    # handler, as that handler will gracefully shut down any running
+    # synchronizers on receiving a SIGTERM
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, etcd_key, node_type)
         synchronizers.append(syncer)
@@ -117,6 +118,7 @@ def main(args):
     # Now start the plugin threads
     for syncer in synchronizers:
         syncer.start_thread()
+        _log.info("Started thread for plugin %s" % syncer._plugin)
 
     while any([thr.isAlive() for thr in threads]):
         for thr in threads:

--- a/src/metaswitch/clearwater/queue_manager/main.py
+++ b/src/metaswitch/clearwater/queue_manager/main.py
@@ -104,15 +104,19 @@ def main(args):
     synchronizers = []
     threads = []
 
+    # Load the plugins, but don't start them until we've installed the SIGTERM
+    # handler
     for plugin in plugins:
         syncer = EtcdSynchronizer(plugin, local_ip, local_site, etcd_key, node_type)
-        syncer.start_thread()
-
         synchronizers.append(syncer)
         threads.append(syncer.thread)
         _log.info("Loaded plugin %s" % plugin)
 
     utils.install_sigterm_handler(synchronizers)
+
+    # Now start the plugin threads
+    for syncer in synchronizers:
+        syncer.start_thread()
 
     while any([thr.isAlive() for thr in threads]):
         for thr in threads:


### PR DESCRIPTION
This is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2309

We must not start them until we've set up the SIGTERM handler, else an early exception in one of the threads won't trigger the cluster/queue/config manager process to exit.

### Testing
* tested live that adding a wait before installing the SIGTERM handler and starting the threads hit the issue before and doesn't now
* `make verify` , `make test` and `make fvtest` all pass