### PR TITLE
[Reviewer: Krista] Use subprocess call without shell

### DIFF
--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -9,7 +9,7 @@
 import tempfile
 import os
 from os.path import dirname
-import subprocess
+import subprocess, shlex
 import logging
 
 _log = logging.getLogger("etcd_shared.plugin_utils")
@@ -25,12 +25,11 @@ def run_command(command, namespace=None, log_error=True):
     passing to this function.
     """
     if namespace:
-        command = "ip netns exec {} ".format(namespace) + command
+        command = "ip netns exec {} ".format(namespace) + shlex.quote(command)
 
     # Pass the close_fds argument to avoid the pidfile lock being held by
     # child processes
-    p = subprocess.Popen(command,
-                         shell=True,
+    p = subprocess.Popen(shlex.split(command),
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          close_fds=True)


### PR DESCRIPTION
Use subprocess.call with shell="True" risks command injection. 
As part of security check using Bandit, replace all such calls and os.system(command_string) calls with subprocess.call with shell=False (default option, hence not shown in the code). Without shell:
* Command needs to be passed in as a list rather than string literal. shlex.split splits up command string into list of command line argument.

* Pipe symbol no longer works, use subprocess.PIPE to store output of first command and pass into second command
https://security.openstack.org/guidelines/dg_avoid-shell-true.html

# Live test 
(to show the new code works)
1.  Create a Chef deployment using new code and then resize it. 
2.  Cluster manager will kick off etcd and uses new code.
3.  Run live tests and check they pass.

# Command injection explanation
(why new code is more secure)
https://security.openstack.org/guidelines/dg_use-subprocess-securely.html