### PR TITLE
[Reviewer: KH1] Run Bandit analysis from python.mk as part of build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ $(ENV_DIR)/bin/python:
 	$(ENV_DIR)/bin/easy_install distribute
 
 include build-infra/cw-deb.mk
+include build-infra/python.mk
 
 .PHONY: build-eggs
 build-eggs: ${ENV_DIR}/.cluster-mgr-build-eggs ${ENV_DIR}/.queue-mgr-build-eggs ${ENV_DIR}/.config-mgr-build-eggs
@@ -149,3 +150,4 @@ envclean:
 	rm -rf distribute-*.tar.gz
 	rm -rf $(ENV_DIR)
 
+BANDIT_EXCLUDE_LIST = src/metaswitch/clearwater/queue_manager/test/,src/metaswitch/clearwater/plugin_tests/,src/metaswitch/clearwater/etcd_tests/,src/metaswitch/clearwater/etcd_shared/test,src/metaswitch/clearwater/config_manager/test/,src/metaswitch/clearwater/cluster_manager/test/,common,_env,.eggs,debian,build_clustermgr,build_configmgr,build_shared


### PR DESCRIPTION
New python.mk file is added to run Bandit analysis on python code and print high severity issues -
 https://github.com/Metaswitch/clearwater-build-infra/pull/64

This pull request pass in EXCLUDE_LIST and include that analysis as part of make deb. Similar action has been taken for the following repository:
https://github.com/Metaswitch/clearwater-infrastructure/pull/478
https://github.com/Metaswitch/clearwater-craft/pull/83
...(TBD)

Tested by ```make analysis``` and getting:

```
# Scanning python code recursively for security issues using Bandit.
# Files in -x are ignored and only high severity level (-lll) are shown.
/home/ubuntu/clearwater-etcd/_env/bin/easy_install bandit
Searching for bandit
Best match: bandit 1.4.0
Processing bandit-1.4.0-py2.7.egg
bandit 1.4.0 is already the active version in easy-install.pth
Installing bandit script to /home/ubuntu/clearwater-etcd/_env/bin
Installing bandit-baseline script to /home/ubuntu/clearwater-etcd/_env/bin
Installing bandit-config-generator script to /home/ubuntu/clearwater-etcd/_env/bin

Using /home/ubuntu/clearwater-etcd/_env/lib/python2.7/site-packages/bandit-1.4.0-py2.7.egg
Processing dependencies for bandit
Finished processing dependencies for bandit
/home/ubuntu/clearwater-etcd/_env/bin/bandit -r . -x "src/metaswitch/clearwater/queue_manager/test/,src/metaswitch/clearwater/plugin_tests/,src/metaswitch/clearwater/etcd_tests/,src/metaswitch/clearwater/etcd_shared/test,src/metaswitch/clearwater/config_manager/test/,src/metaswitch/clearwater/cluster_manager/test/,common,_env,.eggs,debian,build_clustermgr,build_configmgr,build_shared" -lll
/home/ubuntu/clearwater-etcd/_env/local/lib/python2.7/site-packages/setuptools-24.0.0-py2.7.egg/pkg_resources/__init__.py:1268: UserWarning: /home/ubuntu/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 2.7.6
99 [0.. 50.. ]
Run started:2017-08-03 18:03:53.142167

Test results:
>> Issue: [B602:subprocess_popen_with_shell_equals_true] subprocess call with shell=True identified, security issue.
   Severity: High   Confidence: High
   Location: ./clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py:31
30          command = "/usr/share/clearwater/bin/run-in-signaling-namespace nodetool describecluster | grep -v \"^xss = \" | tr \"\t\" \" \""
31          desc_cluster_output = subprocess.check_output(command, shell=True)
32          doc = yaml.load(desc_cluster_output)

--------------------------------------------------
>> Issue: [B602:subprocess_popen_with_shell_equals_true] subprocess call with shell=True identified, security issue.
   Severity: High   Confidence: High
   Location: ./src/clearwater_etcd_plugins/clearwater_cassandra/cassandra_failed_plugin.py:59
58                  output = subprocess.check_output(in_sig_namespace(status_command),
59                                                   shell=True,
60                                                   stderr=subprocess.STDOUT)
61                  _log.debug("Nodetool status succeeded and printed output {!r}".
62                             format(output))

--------------------------------------------------
>> Issue: [B602:subprocess_popen_with_shell_equals_true] subprocess call with shell=True identified, security issue.
   Severity: High   Confidence: High
   Location: ./src/metaswitch/clearwater/etcd_shared/plugin_utils.py:33
32          p = subprocess.Popen(command,
33                               shell=True,
34                               stdout=subprocess.PIPE,
35                               stderr=subprocess.PIPE,
36                               close_fds=True)
37          stdout, stderr = p.communicate()
38          if p.returncode != 0:

--------------------------------------------------

Code scanned:
        Total lines of code: 3713
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 32
                Medium: 3
                High: 3
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 38
Files skipped (0):
make: *** [analysis] Error 1
```