### PR TITLE
Allow an optional etcd IP to be passed to mark_node_failed

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
@@ -15,14 +15,19 @@ etcd_key=clearwater
 
 . /usr/share/clearwater/utils/check-root-permissions 1
 
-if [ $# -ne 3 ]
+if [ $# -ne 3 ] && [ $# -ne 4]
 then
   echo "Usage: mark_node_failed [node_type] [datastore] [failed_node_ip]"
+  echo "       mark_node_failed [node_type] [datastore] [failed_node_ip] [etcd_ip]"
   exit 1
 fi
 
 node_type=$1
 datastore=$2
 dead_node_ip=$3
+# If etcd_ip is not provided, first default to management_local_ip, and then
+# default to local_ip.
+etcd_ip=${4:-$management_local_ip}
+etcd_ip=${etcd_ip:-$local_ip}
 
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py ${management_local_ip:-$local_ip} $local_site_name $node_type $datastore $dead_node_ip $etcd_key
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py $etcd_ip $local_site_name $node_type $datastore $dead_node_ip $etcd_key

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
@@ -15,7 +15,7 @@ etcd_key=clearwater
 
 . /usr/share/clearwater/utils/check-root-permissions 1
 
-if [ $# -ne 3 ] && [ $# -ne 4]
+if [ $# -ne 3 ] && [ $# -ne 4 ]
 then
   echo "Usage: mark_node_failed [node_type] [datastore] [failed_node_ip]"
   echo "       mark_node_failed [node_type] [datastore] [failed_node_ip] [etcd_ip]"

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
@@ -17,8 +17,7 @@ etcd_key=clearwater
 
 if [ $# -ne 3 ] && [ $# -ne 4 ]
 then
-  echo "Usage: mark_node_failed [node_type] [datastore] [failed_node_ip]"
-  echo "       mark_node_failed [node_type] [datastore] [failed_node_ip] [etcd_ip]"
+  echo "Usage: mark_node_failed <node_type> <datastore> <failed_node_ip> [<etcd_ip>]"
   exit 1
 fi
 

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
@@ -27,7 +27,7 @@ logging.basicConfig(filename=logfile,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                     level=logging.DEBUG)
 
-local_ip = sys.argv[1]
+etcd_ip = sys.argv[1]
 site = sys.argv[2]
 node_type = sys.argv[3]
 datastore = sys.argv[4]
@@ -41,12 +41,12 @@ if datastore == "cassandra":
   try:
     sys.path.append("/usr/share/clearwater/clearwater-cluster-manager/failed_plugins")
     from cassandra_failed_plugin import CassandraFailedPlugin
-    error_syncer = EtcdSynchronizer(CassandraFailedPlugin(key, dead_node_ip), dead_node_ip, etcd_ip=local_ip, force_leave=True)
+    error_syncer = EtcdSynchronizer(CassandraFailedPlugin(key, dead_node_ip), dead_node_ip, etcd_ip=etcd_ip, force_leave=True)
   except ImportError:
     print "You must run mark_node_failed on a node that has Cassandra installed to remove a node from a Cassandra cluster"
     sys.exit(1)
 else:
-  error_syncer = EtcdSynchronizer(NullPlugin(key), dead_node_ip, etcd_ip=local_ip, force_leave=True)
+  error_syncer = EtcdSynchronizer(NullPlugin(key), dead_node_ip, etcd_ip=etcd_ip, force_leave=True)
 
 print "Marking node as failed and removing it from the cluster - will take at least 30 seconds"
 # Move the dead node into ERROR state to allow in-progress operations to
@@ -62,7 +62,7 @@ error_syncer.thread.join()
 
 print "Process complete - %s has left the cluster" % dead_node_ip
 
-c = etcd.Client(local_ip, 4000)
+c = etcd.Client(etcd_ip, 4000)
 new_state = c.get(key).value
 
 logging.info("New etcd state (after removing %s) is %s" % (dead_node_ip, new_state))


### PR DESCRIPTION
Unfortunately the "Usage" statement for all the scripts uses [] to indicate a variable, rather than an optional variable. Since there's no precedent for how to describe optional variables, I chose the approach of two different usage statements.

This is required for DM. This implies that we support not using the local etcd client when marking node failed.