### PR TITLE
Mark node failed ignore if not in cluster

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
@@ -13,9 +13,8 @@ from metaswitch.clearwater.cluster_manager.etcd_synchronizer import \
     EtcdSynchronizer
 from metaswitch.clearwater.cluster_manager.null_plugin import \
     NullPlugin
-from metaswitch.clearwater.etcd_shared.plugin_utils import run_command
 
-def make_key(site, node_type, datatore, etcd_key):
+def make_key(site, node_type, datastore, etcd_key):
     if datastore == "cassandra":
         return "/{}/{}/clustering/{}".format(etcd_key, node_type, datastore)
     else:

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
@@ -9,6 +9,8 @@ import os
 from os import sys
 import etcd
 import logging
+from metaswitch.clearwater.cluster_manager.cluster_state import \
+    ClusterInfo
 from metaswitch.clearwater.cluster_manager.etcd_synchronizer import \
     EtcdSynchronizer
 from metaswitch.clearwater.cluster_manager.null_plugin import \
@@ -46,6 +48,14 @@ if datastore == "cassandra":
     sys.exit(1)
 else:
   error_syncer = EtcdSynchronizer(NullPlugin(key), dead_node_ip, etcd_ip=etcd_ip, force_leave=True)
+
+# Check that the dead node is even a member of the cluster
+etcd_result, idx = error_syncer.read_from_etcd(wait=False)
+cluster_info = ClusterInfo(etcd_result)
+
+if cluster_info.local_state(dead_node_ip) is None:
+    print "Not in cluster - no work required"
+    sys.exit(0)
 
 print "Marking node as failed and removing it from the cluster - will take at least 30 seconds"
 # Move the dead node into ERROR state to allow in-progress operations to


### PR DESCRIPTION
Testing done:

```
[scn]clearwater@scn-1:~$ sudo cw-mark_node_failed "scn" "memcached" 173.16.1.49
Detailed output being sent to /var/log/clearwater-etcd/mark_node_failed.log
Marking node as failed and removing it from the cluster - will take at least 30 seconds
Process complete - 173.16.1.49 has left the cluster

[scn]clearwater@scn-1:~$ sudo cw-mark_node_failed "scn" "memcached" 173.16.1.49
Detailed output being sent to /var/log/clearwater-etcd/mark_node_failed.log
Not in cluster - no work required

[scn]clearwater@scn-1:~$ sudo cw-mark_node_failed "scn" "memcached" 1.2.3.4
Detailed output being sent to /var/log/clearwater-etcd/mark_node_failed.log
Not in cluster - no work required

[scn]clearwater@scn-1:~$ /usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state
This script prints the status of the Cassandra, Chronos, and Memcached clusters.
This node (173.16.1.50) should be in the Cassandra, Chronos and Memcached clusters.

Describing the Cassandra cluster:
  The cluster is stable
    173.16.1.50 is in state normal
    173.16.1.49 is in state normal
    173.16.1.47 is in state normal

Describing the Chronos cluster:
  The cluster is stable
    173.16.1.50 is in state normal
    173.16.1.49 is in state normal
    173.16.1.47 is in state normal

Describing the Memcached cluster:
  The cluster is stable
    173.16.1.50 is in state normal
    173.16.1.47 is in state normal

Describing the Memcached cluster:
  The cluster is stable
```

