### PR TITLE
Revert "[Reviewer: KH1] Run Bandit analysis from python.mk as part of build process"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ $(ENV_DIR)/bin/python:
 	$(ENV_DIR)/bin/easy_install distribute
 
 include build-infra/cw-deb.mk
-include build-infra/python.mk
 
 .PHONY: build-eggs
 build-eggs: ${ENV_DIR}/.cluster-mgr-build-eggs ${ENV_DIR}/.queue-mgr-build-eggs ${ENV_DIR}/.config-mgr-build-eggs
@@ -150,4 +149,3 @@ envclean:
 	rm -rf distribute-*.tar.gz
 	rm -rf $(ENV_DIR)
 
-BANDIT_EXCLUDE_LIST = src/metaswitch/clearwater/queue_manager/test/,src/metaswitch/clearwater/plugin_tests/,src/metaswitch/clearwater/etcd_tests/,src/metaswitch/clearwater/etcd_shared/test,src/metaswitch/clearwater/config_manager/test/,src/metaswitch/clearwater/cluster_manager/test/,common,_env,.eggs,debian,build_clustermgr,build_configmgr,build_shared


### PR DESCRIPTION
Reverts Metaswitch/clearwater-etcd#473

Revert due to accidentally committing changes in submodules