### PR TITLE
Bandit check as part of build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ $(ENV_DIR)/bin/python:
 	$(ENV_DIR)/bin/easy_install "setuptools==24"
 	$(ENV_DIR)/bin/easy_install distribute
 
+BANDIT_EXCLUDE_LIST = src/metaswitch/clearwater/queue_manager/test/,src/metaswitch/clearwater/plugin_tests/, src/metaswitch/clearwater/etcd_tests/,src/metaswitch/clearwater/etcd_shared/test, src/metaswitch/clearwater/config_manager/test/,src/metaswitch/clearwater/cluster_manager/test/,common,_env, .eggs,debian,build_clustermgr,build_configmgr,build_shared
 include build-infra/cw-deb.mk
+include build-infra/python.mk
 
 .PHONY: build-eggs
 build-eggs: ${ENV_DIR}/.cluster-mgr-build-eggs ${ENV_DIR}/.queue-mgr-build-eggs ${ENV_DIR}/.config-mgr-build-eggs


### PR DESCRIPTION
Re-commit of https://github.com/Metaswitch/clearwater-etcd/pull/473, which was reverted due to accidentally committing changes in submodules.