### PR TITLE
Fix up mark_node_failed for when management_local_ip is unset

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed
@@ -26,7 +26,7 @@ datastore=$2
 dead_node_ip=$3
 # If etcd_ip is not provided, first default to management_local_ip, and then
 # default to local_ip.
-etcd_ip=${4:-$management_local_ip}
-etcd_ip=${etcd_ip:-$local_ip}
+local_ip=${management_local_ip:-$local_ip}
+etcd_ip=${4:-$local_ip}
 
 /usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py $etcd_ip $local_site_name $node_type $datastore $dead_node_ip $etcd_key


### PR DESCRIPTION
The code "worked", but `set -u` was throwing up errors to do with unset variables, and `set -e` was causing the script to crash, so I've jiggled things around.

Have tested calling mark_node_failed with the following combinations being set:
- local_ip
- local_ip, etcd_ip
- local_ip, management_local_ip, etcd_ip
- local_ip, management_local_ip
Not exhaustive, but close enough.