### PR TITLE
Fix mock calls to run_command in UT

### DIFF
--- a/src/metaswitch/clearwater/plugin_tests/test_apply_chronos_shared_config_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_apply_chronos_shared_config_plugin.py
@@ -24,12 +24,12 @@ class TestApplyChronosSharedConfigPlugin(unittest.TestCase):
         plugin = ApplyChronosSharedConfigPlugin({})
 
         expected_command_call_list = \
-            [mock.call("service chronos stop"),
+            [mock.call(['service', 'chronos', 'stop']),
              mock.call().__nonzero__(),
-             mock.call("service chronos wait-sync"),
+             mock.call(['service', 'chronos', 'wait-sync']),
              mock.call().__nonzero__(),
-             mock.call("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue"\
-                       " remove_success apply_chronos_shared_config"),
+             mock.call(['/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue', \
+                       'remove_success', 'apply_chronos_shared_config']),
              mock.call().__nonzero__()]
 
         # Call the plugin hook

--- a/src/metaswitch/clearwater/plugin_tests/test_apply_config_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_apply_config_plugin.py
@@ -50,11 +50,11 @@ class TestApplyConfigPlugin(unittest.TestCase):
         mock_os_listdir.return_value = ["test_restart_script"]
 
         expected_command_call_list = \
-            [mock.call("service clearwater-infrastructure restart"),
-             mock.call("/usr/share/clearwater/infrastructure/scripts/restart/test_restart_script"),
-             mock.call("/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py"),
-             mock.call("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue"\
-                       " remove_success apply_config_key")]
+            [mock.call(['service', 'clearwater-infrastructure', 'restart']),
+             mock.call(['/usr/share/clearwater/infrastructure/scripts/restart/test_restart_script']),
+             mock.call(['/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py']),
+             mock.call(['/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue', \
+                       'remove_success', 'apply_config_key'])]
 
         # Call the plugin hook
         plugin.at_front_of_queue()
@@ -86,11 +86,11 @@ class TestApplyConfigPlugin(unittest.TestCase):
         mock_os_listdir.return_value = ["test_restart_script"]
 
         expected_command_call_list = \
-            [mock.call("service clearwater-infrastructure restart"),
-             mock.call("/usr/share/clearwater/infrastructure/scripts/restart/test_restart_script"),
-             mock.call("/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py"),
-             mock.call("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue"\
-                       " remove_failure apply_config_key")]
+            [mock.call(['service', 'clearwater-infrastructure', 'restart']),
+             mock.call(['/usr/share/clearwater/infrastructure/scripts/restart/test_restart_script']),
+             mock.call(['/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py']),
+             mock.call(['/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue', \
+                       'remove_failure', u'apply_config_key'])]
 
         # Call the plugin hook
         plugin.at_front_of_queue()
@@ -122,10 +122,10 @@ class TestApplyConfigPlugin(unittest.TestCase):
         mock_os_listdir.return_value = ["test_restart_script"]
 
         expected_command_call_list = \
-            [mock.call("service clearwater-infrastructure restart"),
-             mock.call("/usr/share/clearwater/infrastructure/scripts/restart/test_restart_script"),
-             mock.call("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue"\
-                       " remove_success apply_config_key")]
+            [mock.call(['service', 'clearwater-infrastructure', 'restart']),
+             mock.call(['/usr/share/clearwater/infrastructure/scripts/restart/test_restart_script']),
+             mock.call(['/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue', \
+                       'remove_success', 'apply_config_key'])]
 
         # Call the plugin hook
         plugin.at_front_of_queue()

--- a/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_cassandra_plugin.py
@@ -143,9 +143,11 @@ seed_provider:\n\
         # These calls cover restarting cassandra, and the commands called by 
         # the plugin in wait_for_cassandra.
         run_command_call_list = \
-            [mock.call("start-stop-daemon -K -p /var/run/cassandra/cassandra.pid -R TERM/30/KILL/5"),
-             mock.call("/usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period", log_error=False),
-             mock.call("sudo service clearwater-infrastructure restart")]
+            [mock.call(['start-stop-daemon', '-K', '-p', \
+            '/var/run/cassandra/cassandra.pid', '-R', 'TERM/30/KILL/5']),
+             mock.call(['/usr/share/clearwater/bin/poll_cassandra.sh', \
+             '--no-grace-period'], log_error=False),
+             mock.call(['sudo', 'service', 'clearwater-infrastructure', 'restart'])]
 
         mock_os_path.assert_has_calls(path_exists_call_list)
         mock_os_remove.assert_has_calls(path_remove_call_list)
@@ -223,10 +225,11 @@ seed_provider:\n\
 
         # Check the additional calls that we should make when destructive_restart = True actually happen.
         run_command_call_list = \
-            [mock.call("start-stop-daemon -K -p /var/run/cassandra/cassandra.pid -R TERM/30/KILL/5"),
-             mock.call("rm -rf /var/lib/cassandra/"),
-             mock.call("mkdir -m 755 /var/lib/cassandra"),
-             mock.call("chown -R cassandra /var/lib/cassandra")]
+            [mock.call(['start-stop-daemon', '-K', '-p', \
+            '/var/run/cassandra/cassandra.pid', '-R', 'TERM/30/KILL/5']),
+             mock.call(['rm', '-rf', '/var/lib/cassandra/']),
+             mock.call(['mkdir', '-m', '755', '/var/lib/cassandra']),
+             mock.call(['chown', '-R', 'cassandra', '/var/lib/cassandra'])]
         mock_run_command.assert_has_calls(run_command_call_list)
 
 
@@ -343,7 +346,8 @@ seed_provider:\n\
         # Check that the only call to run_command was to stop
         # cassandra, not to remove the data directory
         mock_run_command.assert_called_once_with(\
-            "start-stop-daemon -K -p /var/run/cassandra/cassandra.pid -R TERM/30/KILL/5")
+            ['start-stop-daemon', '-K', '-p', \
+            '/var/run/cassandra/cassandra.pid', '-R', 'TERM/30/KILL/5'])
 
 
     # run_command returns 0 if a command completes successfully, but python mocks
@@ -384,8 +388,9 @@ seed_provider:\n\
         # Set the expected calls to the mock commands, making sure that we run
         # the nodetool decommission command
         run_command_call_list = \
-            [mock.call("/usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period", log_error=False),
-             mock.call("nodetool decommission", self.plugin._sig_namespace)]
+            [mock.call(["/usr/share/clearwater/bin/poll_cassandra.sh", \
+                "--no-grace-period"], log_error=False),
+             mock.call(["nodetool", "decommission"], self.plugin._sig_namespace)]
 
         mock_run_command.assert_has_calls(run_command_call_list)
 

--- a/src/metaswitch/clearwater/plugin_tests/test_chronos_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_chronos_plugin.py
@@ -76,7 +76,7 @@ class TestChronosPlugin(unittest.TestCase):
         args = mock_safely_write.call_args
 
         # Catch the call to reload chronos
-        mock_run_command.assert_called_once_with('service chronos reload')
+        mock_run_command.assert_called_once_with(['service', 'chronos', 'reload'])
 
         # Check the plugin is attempting to write to the correct location
         self.assertEqual("/etc/chronos/chronos_cluster.conf", args[0][0])

--- a/src/metaswitch/clearwater/plugin_tests/test_chronos_shared_config_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_chronos_shared_config_plugin.py
@@ -37,5 +37,6 @@ class TestConfigManagerPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r")
         mock_safely_write.assert_called_once_with(plugin.file(), new_config_string)
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_chronos_shared_config")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue", \
+        "add", "apply_chronos_shared_config"])
         mock_alarm.update_file.assert_called_once_with(plugin.file())

--- a/src/metaswitch/clearwater/plugin_tests/test_dns_json_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_dns_json_plugin.py
@@ -38,7 +38,7 @@ class TestDNSJSONPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r")
         mock_safely_write.assert_called_once_with(plugin.file(), new_config_string)
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_dns_json")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_dns_json"])
         mock_alarm.update_file.assert_called_once_with(plugin.file())
 
     @mock.patch('clearwater_etcd_plugins.clearwater_config_manager.dns_json_plugin.safely_write')
@@ -84,6 +84,6 @@ class TestDNSJSONPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r")
         mock_safely_write.assert_called_once_with(plugin.file(), plugin.default_value())
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_dns_json")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_dns_json"])
         mock_alarm.update_file.assert_called_once_with(plugin.file())
 

--- a/src/metaswitch/clearwater/plugin_tests/test_fallback_ifcs_xml_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_fallback_ifcs_xml_plugin.py
@@ -37,7 +37,7 @@ class TestFallbackIFCsXMLPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r")
         mock_safely_write.assert_called_once_with(plugin.file(), new_config_string)
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_fallback_ifcs_xml")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_fallback_ifcs_xml"])
         mock_alarm.update_file.assert_called_once_with(plugin.file())
 
 
@@ -84,5 +84,5 @@ class TestFallbackIFCsXMLPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r")
         mock_safely_write.assert_called_once_with(plugin.file(), plugin.default_value())
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_fallback_ifcs_xml")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_fallback_ifcs_xml"])
         mock_alarm.update_file.assert_called_once_with(plugin.file())

--- a/src/metaswitch/clearwater/plugin_tests/test_memcached_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_memcached_plugin.py
@@ -65,7 +65,7 @@ class TestMemcachedPlugin(unittest.TestCase):
         args = mock_safely_write.call_args
 
         # Catch the call to reload memcached
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_memcached_users")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_memcached_users"])
 
         # Check the plugin is attempting to write to the correct location
         self.assertEqual("/etc/clearwater/cluster_settings", args[0][0])
@@ -136,7 +136,7 @@ class TestMemcachedPlugin(unittest.TestCase):
         args = mock_safely_write.call_args
 
         # Catch the call to reload memcached
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_memcached_users")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_memcached_users"])
 
         # Check the plugin is attempting to write to the correct location
         self.assertEqual("/etc/clearwater/cluster_settings", args[0][0])
@@ -188,7 +188,7 @@ class TestMemcachedPlugin(unittest.TestCase):
         args = mock_safely_write.call_args
 
         # Catch the call to reload memcached
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_memcached_users")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_memcached_users"])
 
         # Check the plugin is attempting to write to the correct location
         self.assertEqual("/etc/clearwater/remote_cluster_settings", args[0][0])

--- a/src/metaswitch/clearwater/plugin_tests/test_shared_config_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_shared_config_plugin.py
@@ -41,8 +41,9 @@ class TestSharedConfigPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r", encoding="utf-8")
         mock_safely_write.assert_called_once_with(plugin.file(), new_config_string)
-        mock_run_command.assert_called_once_with\
-            ("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_config_key")
+        mock_run_command.assert_called_once_with \
+            (['/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue', \
+            'add', 'apply_config_key'])
         mock_alarm.update_file.assert_called_once_with(plugin.file())
 
     @mock.patch('clearwater_etcd_plugins.clearwater_config_manager.shared_config_plugin.safely_write')

--- a/src/metaswitch/clearwater/plugin_tests/test_shared_ifcs_xml_plugin.py
+++ b/src/metaswitch/clearwater/plugin_tests/test_shared_ifcs_xml_plugin.py
@@ -38,7 +38,7 @@ class TestSharedIFCsXMLPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r")
         mock_safely_write.assert_called_once_with(plugin.file(), new_config_string)
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_shared_ifcs_xml")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_shared_ifcs_xml"])
         mock_alarm.update_file.assert_called_once_with(plugin.file())
 
 
@@ -85,5 +85,5 @@ class TestSharedIFCsXMLPlugin(unittest.TestCase):
         # Test assertions
         mock_open.assert_called_once_with(plugin.file(), "r")
         mock_safely_write.assert_called_once_with(plugin.file(), plugin.default_value())
-        mock_run_command.assert_called_once_with("/usr/share/clearwater/bin/reload_shared_ifcs_xml")
+        mock_run_command.assert_called_once_with(["/usr/share/clearwater/bin/reload_shared_ifcs_xml"])
         mock_alarm.update_file.assert_called_once_with(plugin.file())


### PR DESCRIPTION
As run_command now takes an array of arguments rather than a command string