### PR TITLE
[Reviewer: EM] Check for etcd connection on mark_node_failed

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
@@ -53,7 +53,7 @@ else:
 etcd_result, idx = error_syncer.read_from_etcd(wait=False, timeout=10)
 
 if etcd_result is None:
-    print "ERROR:  Failed to contact etcd cluster on '{}' - node not removed".format(etcd_ip)
+    print "Failed to contact etcd cluster on '{}' - node not removed".format(etcd_ip)
     sys.exit(1)
 
 cluster_info = ClusterInfo(etcd_result)

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/mark_node_failed.py
@@ -50,7 +50,12 @@ else:
   error_syncer = EtcdSynchronizer(NullPlugin(key), dead_node_ip, etcd_ip=etcd_ip, force_leave=True)
 
 # Check that the dead node is even a member of the cluster
-etcd_result, idx = error_syncer.read_from_etcd(wait=False)
+etcd_result, idx = error_syncer.read_from_etcd(wait=False, timeout=10)
+
+if etcd_result is None:
+    print "ERROR:  Failed to contact etcd cluster on '{}' - node not removed".format(etcd_ip)
+    sys.exit(1)
+
 cluster_info = ClusterInfo(etcd_result)
 
 if cluster_info.local_state(dead_node_ip) is None:

--- a/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
@@ -284,12 +284,12 @@ class CommonEtcdSynchronizer(object):
 
     # Read the state of the cluster from etcd (optionally waiting for a changed
     # state). Returns None if nothing could be read.
-    def read_from_etcd(self, wait=True):
+    def read_from_etcd(self, wait=True, timeout=None):
         result = None
         wait_index = None
 
         try:
-            result = self._client.read(self.key(), quorum=True)
+            result = self._client.read(self.key(), quorum=True, timeout=timeout)
             wait_index = result.etcd_index + 1
 
             if wait:


### PR DESCRIPTION
Ellie - please can you review this (I'm picking on you, because you recently reviewed a fix in a similar area from CC3).

This is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2351

Now we check to ensure that we can contact etcd before we try to mark a node as failed, improving error output.  I've also reduced the default timeout, as it seemed unnecessary for this command to wait four minutes before reporting failure (4 retries @ 60 seconds).

Testing-wise, I've verified this by passing in a bad etcd IP address, and ensuring that we get a timeout, and an error response.