### PR TITLE
[Reviewer: Ellie] Log exception as exceptions

### DIFF
--- a/src/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
+++ b/src/metaswitch/clearwater/cluster_manager/synchronization_fsm.py
@@ -35,11 +35,13 @@ def safe_plugin(f, cluster_view, new_state=None):
         # return None. This will keep this node in the same state, pausing the
         # scale-up (which will raise an alarm) until someone looks into it and
         # fixes the issue.
-        _log.error("Call to {}.{} with cluster {} caused exception {!r}".
-                   format(f.__self__.__class__.__name__,
-                          f.__name__,
-                          cluster_view,
-                          e))
+        _log.exception(
+                "Call to {}.{} with cluster {} caused exception {!r}".
+                format(
+                    f.__self__.__class__.__name__,
+                    f.__name__,
+                    cluster_view,
+                    e))
         return None
 
 


### PR DESCRIPTION
This made it a lot harder to debug as we don't currently get stacktraces 😞 .

`make verify test` passes, and I've confirmed the fix is good live.