### PR TITLE
[Reviewer: Krista] Extend command args

### DIFF
--- a/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
+++ b/src/metaswitch/clearwater/etcd_shared/plugin_utils.py
@@ -25,7 +25,7 @@ def run_command(command_args, namespace=None, log_error=True):
     in as an array instead of a string.
     """
     if namespace:
-        command_args = ['ip', 'netns', 'exec', namespace].extend(command_args)
+        command_args[0:0] = ['ip', 'netns', 'exec', namespace]
 
     # Pass the close_fds argument to avoid the pidfile lock being held by
     # child processes


### PR DESCRIPTION
Prepend the command args with the namespace args if we're using the signaling namespace (the previous code set command_args to None).

I've not tested live as I've got no easy way of getting a system with signaling namespace. I've tested the python change in isolation.