### PR TITLE
[Reviewer: Seb] Improve init checking of healthy_cluster_view

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -175,12 +175,23 @@ setup_etcdctl_peers()
           # We want to stip anything up to and including the first = character
           # so we can select etcd_cluster or etcd_proxy appropriately
           healthy_cluster=$(sed -e 's/.*=//' < $HEALTHY_CLUSTER_VIEW)
-          if [ -n "$etcd_cluster" ]
+
+          # We also want to ensure that the file was not just empty, so verify
+          # that stripping white space still leaves something
+          if [[ -z "${healthy_cluster// /}" ]]
           then
-            etcd_cluster=$healthy_cluster
-          elif [ -n "$etcd_proxy" ]
+            log_debug "healthy cluster view was empty, using config values instead"
+          elif
           then
-            etcd_proxy=$healthy_cluster
+            # Set etcd_cluster or etcd_proxy to the values we found in the
+            # healthy cluster view, based on what is provided in config
+            if [ -n "$etcd_cluster" ]
+            then
+              etcd_cluster=$healthy_cluster
+            elif [ -n "$etcd_proxy" ]
+            then
+              etcd_proxy=$healthy_cluster
+            fi
           fi
         fi
 

--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -181,8 +181,7 @@ setup_etcdctl_peers()
           if [[ -z "${healthy_cluster// /}" ]]
           then
             log_debug "healthy cluster view was empty, using config values instead"
-          elif
-          then
+          else
             # Set etcd_cluster or etcd_proxy to the values we found in the
             # healthy cluster view, based on what is provided in config
             if [ -n "$etcd_cluster" ]


### PR DESCRIPTION
On the dogfood system i was seeing etcd fail to start, logging out that i needed to specify either etcd_cluster or etcd_proxy. From that i worked out that we must have been checking the healthy_member_list file, and finding something, but that the something was blank. Double checking on the system, and sure enough the file was present but empty.
I'm not sure how we got into that state, but this PR adds a step to verify that what we get from the healthy members list is not just blank space. I've also added a bit more in the way of comments, so hopefully it's a bit clearer in future.

To test the bash, i ran the following in my shell:
```
$ healthy_cluster="asd  123"
$ if [[ -z "${healthy_cluster// /}" ]]; then echo hello; fi
$ healthy_cluster="   "
$ if [[ -z "${healthy_cluster// /}" ]]; then echo hello; fi
hello
```
I'm going to create a chef deployment to double check it doesn't somehow kill everything, and i'll set the file to blank space to verify it works live too.