### PR TITLE
[Reviewer: Krista] Fix up output to remove Cassandra

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state
@@ -10,7 +10,6 @@ set -ue
 
 local_site_name=site1
 site_names=
-etcd_version=
 . /etc/clearwater/config
 
 if [ $# -ne 0 ]
@@ -19,4 +18,4 @@ then
   exit 1
 fi
 
-/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py "${management_local_ip:-$local_ip}" "$local_ip" "$local_site_name" "$site_names" "$etcd_version"
+/usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py "${management_local_ip:-$local_ip}" "$local_ip" "$local_site_name" "$site_names"


### PR DESCRIPTION
This fixes the output of  check_cluster_state to ignore empty keys and to not mention Cassandra. I've also removed some dead code (etcd_version, remote memcached plugin).

Tested live.

Output before fix:
```
This script prints the status of the Cassandra, Chronos, and Memcached clusters                                                                                                                                                              in the local site (gdc).
This node (10.225.167.115) should not be in any cluster.

Describing the Cassandra cluster:
  The cluster is stable

Describing the Chronos cluster:
  The cluster is stable
    10.225.167.114 is in state normal

Describing the Memcached cluster:
  The cluster is stable
    10.225.167.114 is in state normal

```

Output after fix:
```
This script prints the status of the data store clusters in the local site (gdc).

This node (10.225.167.115) should not be in any cluster.

Describing the Chronos cluster in site gdc:
  The cluster is stable.
    10.225.167.114 is in state normal.

Describing the Memcached cluster in site gdc:
  The cluster is stable.
    10.225.167.114 is in state normal.

```
