### PR TITLE
Fixing issue 2400

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state
@@ -19,3 +19,4 @@ then
 fi
 
 /usr/share/clearwater/clearwater-cluster-manager/env/bin/python /usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py "${management_local_ip:-$local_ip}" "$local_ip" "$local_site_name" "$site_names"
+exit $?

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
@@ -17,7 +17,10 @@ sites = sys.argv[4]
 
 client = etcd.Client(mgmt_node, 4000)
 
+
 def describe_clusters():
+    """This function returns the the number of unstable clusters it is
+     checking """
     # Pull out all the clearwater keys.
     key = "/?recursive=True"
 
@@ -71,7 +74,7 @@ def describe_clusters():
             # The key isn't to do with clustering, skip it
             continue
 
-    exit_value = 0
+    unstable_clusters = 0
     for (key, value) in sorted(start_with_store.items()):
         key_parts = key.split('-')
         store_name = key_parts[0]
@@ -91,7 +94,7 @@ def describe_clusters():
             cluster_value += "  The cluster is stable.\n"
         else:
             cluster_value += "  The cluster is *not* stable.\n"
-            exit_value = 1
+            unstable_clusters += 1
 
         if len(cluster) != 0:
             for node, state in cluster.iteritems():
@@ -101,6 +104,11 @@ def describe_clusters():
 
     # This makes sure an error value is returned when the clusters are not
     # stable
-    sys.exit(exit_value)
+    return unstable_clusters
 
-describe_clusters()
+return_code = describe_clusters()
+if return_code == 0:
+    sys.exit()
+else:
+    clusters_state = "{} unstable cluster(s)".format(return_code)
+    sys.exit(clusters_state)

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
@@ -71,6 +71,7 @@ def describe_clusters():
             # The key isn't to do with clustering, skip it
             continue
 
+    exit_value = 0
     for (key, value) in sorted(start_with_store.items()):
         key_parts = key.split('-')
         store_name = key_parts[0]
@@ -90,6 +91,7 @@ def describe_clusters():
             cluster_value += "  The cluster is stable.\n"
         else:
             cluster_value += "  The cluster is *not* stable.\n"
+            exit_value = 1
 
         if len(cluster) != 0:
             for node, state in cluster.iteritems():
@@ -97,4 +99,5 @@ def describe_clusters():
 
             print cluster_value
 
+    sys.exit(exit_value)
 describe_clusters()

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
@@ -99,5 +99,8 @@ def describe_clusters():
 
             print cluster_value
 
+    # This makes sure an error value is returned when the clusters are not
+    # stable
     sys.exit(exit_value)
+
 describe_clusters()


### PR DESCRIPTION
This made sure the check_cluster_state script returned a value when it was run. This allows an error value of 1 to be returned when the clusters are not stable. Or 1 to be returned when stable. 