### PR TITLE
[Reviewer: Richard] Set up queue-mgr logging to use gmtime, not localtime

### DIFF
--- a/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue.py
+++ b/clearwater-queue-manager.root/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue.py
@@ -10,16 +10,22 @@ import etcd
 import logging
 from metaswitch.clearwater.queue_manager.etcd_synchronizer import EtcdSynchronizer, WriteToEtcdStatus
 from metaswitch.clearwater.queue_manager.null_plugin import NullPlugin
-from time import sleep
+from time import sleep, gmtime
 
 def make_key(site, clearwater_key, queue_key):
     return "/{}/{}/configuration/{}".format(clearwater_key, site, queue_key)
 
 logfile = "/var/log/clearwater-queue-manager/queue_operation.log"
-logging.basicConfig(filename=logfile,
-                    format="%(asctime)s.%(msecs)03d UTC %(levelname)s %(filename)s:%(lineno)d: %(message)s",
-                    datefmt="%d-%m-%Y %H:%M:%S",
-                    level=logging.DEBUG)
+_log = logging.getLogger("queue_manager.modify_nodes")
+_log.setLevel(logging.DEBUG)
+
+handler = logging.FileHandler(logfile)
+handler.setLevel(logging.DEBUG)
+log_format = logging.Formatter(fmt="%(asctime)s.%(msecs)03d UTC %(levelname)s %(filename)s:%(lineno)d: %(message)s",
+                               datefmt="%d-%m-%Y %H:%M:%S")
+log_format.converter = gmtime
+handler.setFormatter(log_format)
+_log.addHandler(handler)
 
 operation = sys.argv[1]
 local_ip = sys.argv[2]
@@ -28,49 +34,49 @@ node_type = sys.argv[4]
 clearwater_key = sys.argv[5]
 queue_key = sys.argv[6]
 
-logging.info("Using etcd key %s" % queue_key)
+_log.info("Using etcd key %s" % queue_key)
 
 queue_syncer = EtcdSynchronizer(NullPlugin(queue_key), local_ip, site, clearwater_key, node_type)
 
 if operation == "add":
-    logging.debug("Adding %s to queue to restart" % (local_ip + "-" + node_type))
+    _log.debug("Adding %s to queue to restart" % (local_ip + "-" + node_type))
 
     while queue_syncer.add_to_queue() != WriteToEtcdStatus.SUCCESS:
         sleep(2)
 
-    logging.debug("Node successfully added to restart queue")
+    _log.debug("Node successfully added to restart queue")
 elif operation == "remove_success":
-    logging.debug("Removing %s from front of queue" % (local_ip + "-" + node_type))
+    _log.debug("Removing %s from front of queue" % (local_ip + "-" + node_type))
 
     while queue_syncer.remove_from_queue(True) != WriteToEtcdStatus.SUCCESS:
         sleep(2)
 
-    logging.debug("Node successfully removed")
+    _log.debug("Node successfully removed")
 elif operation == "remove_failure":
-    logging.debug("Removing %s from front of queue and marking as errored" % (local_ip + "-" + node_type))
+    _log.debug("Removing %s from front of queue and marking as errored" % (local_ip + "-" + node_type))
 
     while queue_syncer.remove_from_queue(False) != WriteToEtcdStatus.SUCCESS:
         sleep(2)
 
-    logging.debug("Node successfully removed")
+    _log.debug("Node successfully removed")
 elif operation == "force_true":
-    logging.debug("Setting the force value to true")
+    _log.debug("Setting the force value to true")
 
     while queue_syncer.set_force(True) != WriteToEtcdStatus.SUCCESS:
         sleep(2)
 
-    logging.debug("Force value successfully set")
+    _log.debug("Force value successfully set")
 elif operation == "force_false":
-    logging.debug("Setting the force value to false")
+    _log.debug("Setting the force value to false")
 
     while queue_syncer.set_force(False) != WriteToEtcdStatus.SUCCESS:
         sleep(2)
 
-    logging.debug("Force value successfully set")
+    _log.debug("Force value successfully set")
 else:
-    logging.debug("Invalid operation requested")
+    _log.debug("Invalid operation requested")
 
 c = etcd.Client(local_ip, 4000)
 key = make_key(site, clearwater_key, queue_key)
 queue = c.get(key).value
-logging.info("New etcd state is %s" % (queue))
+_log.info("New etcd state is %s" % (queue))


### PR DESCRIPTION
The way we set up logging in the modify_nodes_in_queue script meant we were using the localtime rather than UTC. This was dumb, given the log format includes the string `UTC` after the time stamp.

Set up a node in a different time zone:
```
[vellum-1]ubuntu@ec2-54-158-150-74:~$ sudo dpkg-reconfigure tzdata

Current default time zone: 'Asia/Kuwait'
Local time is now:      Thu Sep 21 19:55:07 AST 2017.
Universal Time is now:  Thu Sep 21 16:55:07 UTC 2017.
```

Prior to the changes, you'd see the following output:
```
[vellum-1]ubuntu@ec2-54-158-150-74:~$ sudo cw-upload_shared_config && tail -n 4 /var/log/clearwater-queue-manager/queue_operation.log
Validating /etc/clearwater/shared_config
Validation of /etc/clearwater/shared_config succeeded
No changes detected in shared configuration file
21-09-2017 19:55:34.927 UTC INFO modify_nodes_in_queue.py:76: New etcd state is {"ERRORED": [], "FORCE": false, "COMPLETED": [], "QUEUED": [{"STATUS": "PROCESSING", "ID": "10.0.5.205-vellum"}]}
21-09-2017 19:55:34.927 UTC INFO alarms.py:169: Shutting down alarm manager.
21-09-2017 19:55:34.928 UTC INFO alarms.py:177: Waiting for alarm manager to quiesce.
21-09-2017 19:55:34.928 UTC INFO alarms.py:163: Alarm manager shut down.
```

with the new changes, you get:
```
[vellum-1]ubuntu@ec2-54-158-150-74:~$ date
Thu Sep 21 20:09:05 AST 2017
[vellum-1]ubuntu@ec2-54-158-150-74:~$ sudo cw-upload_shared_config && tail -n 4 /var/log/clearwater-queue-manager/queue_operation.log
Validating /etc/clearwater/shared_config
Validation of /etc/clearwater/shared_config succeeded
No changes detected in shared configuration file
21-09-2017 17:09:08.484 UTC INFO modify_nodes_in_queue.py:37: Using etcd key apply_config_vellum
21-09-2017 17:09:08.484 UTC DEBUG modify_nodes_in_queue.py:70: Setting the force value to false
21-09-2017 17:09:08.487 UTC DEBUG modify_nodes_in_queue.py:75: Force value successfully set
21-09-2017 17:09:08.488 UTC INFO modify_nodes_in_queue.py:82: New etcd state is {"ERRORED": [], "FORCE": false, "COMPLETED": [], "QUEUED": [{"STATUS": "PROCESSING", "ID": "10.0.5.205-vellum"}]}
```