### PR TITLE
[Reviewer: Richard] Fix site name printing

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_state.py
@@ -64,12 +64,10 @@ def describe_clusters():
 
         if 'clustering' in key_parts:
             if len(key_parts) > 5:
-                site = key_parts[2]
                 store_name = key_parts[5]
             elif len(key_parts) > 4:
-                site = ""
                 store_name = key_parts[4]
-            start_with_store["{}-{}".format(store_name, site)] = value
+            start_with_store["{}-{}".format(store_name, local_site)] = value
         else:
             # The key isn't to do with clustering, skip it
             continue


### PR DESCRIPTION
We specify the local site name on running the script, and i believe we don't run any plugins with anything other than the default site name. 
This just  uses local_site where we would otherwise have used the key site name, or a blank string. 