### PR TITLE
Fixing bug in revision index file location code

### DIFF
--- a/src/metaswitch/clearwater/config_manager/move_config.py
+++ b/src/metaswitch/clearwater/config_manager/move_config.py
@@ -529,7 +529,7 @@ def upload_config(autoconfirm, config_loader, config_type, force, local_store):
 
     # If we reach this point then config upload was successful. Cleaning up
     # the config file we've uploaded makes sure we don't cause confusion later.
-    local_store.config_cleanup()
+    local_store.config_cleanup(config_type)
 
     print "{} successfully uploaded".format(shared_config)
 


### PR DESCRIPTION
We weren't returning the correct file location for the revision index file.

(I also touched up one of the exception texts while I was at it)