### PR TITLE
Fix bug that stopped all rsyslog rule processing after config-manager

### DIFF
--- a/clearwater-config-manager.root/etc/rsyslog.d/35-config-manager.conf
+++ b/clearwater-config-manager.root/etc/rsyslog.d/35-config-manager.conf
@@ -1,4 +1,4 @@
 $FileCreateMode 0644
 $EscapeControlCharactersOnReceive off
 :syslogtag, equals, "clearwater-config-manager", /var/log/clearwater-config-manager/config-manager.log
-:stop
+& :stop


### PR DESCRIPTION
It looks like we stop processing all syslog filters, including the default ones, by not having an ampersand in 35-config-manager.conf.