### PR TITLE
Fix up syntax of Syslog Configuration

### DIFF
--- a/clearwater-config-manager.root/etc/rsyslog.d/35-config-manager.conf
+++ b/clearwater-config-manager.root/etc/rsyslog.d/35-config-manager.conf
@@ -1,4 +1,4 @@
 $FileCreateMode 0644
 $EscapeControlCharactersOnReceive off
-:syslogtag, equals, "clearwater-config-manager", /var/log/clearwater-config-manager/config-manager.log
-:stop
+:syslogtag, isequal, "clearwater-config-manager" /var/log/clearwater-config-manager/config-manager.log
+& stop

--- a/clearwater-config-manager.root/etc/rsyslog.d/35-config-manager.conf
+++ b/clearwater-config-manager.root/etc/rsyslog.d/35-config-manager.conf
@@ -1,4 +1,4 @@
 $FileCreateMode 0644
 $EscapeControlCharactersOnReceive off
-:syslogtag, isequal, "clearwater-config-manager" /var/log/clearwater-config-manager/config-manager.log
+:syslogtag, isequal, "clearwater-config-manager:" /var/log/clearwater-config-manager/config-manager.log
 & stop


### PR DESCRIPTION
The syslog configuration file for clearwater-config-manager contained two syntax errors and a bug:
* An extra comma
* An unnecessary colon before the `stop` command
* A missing `&` before the stop command, meaning that no further processing would happen after this file - and preventing anything from being written to `/var/log/syslog`.

I've checked that this new version passes rsyslogd's config validation using `rsyslogd -N 1`.