### PR TITLE
[Reviewer: MD6] Fixes cw-config to handle being run via console

### DIFF
--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -638,7 +638,19 @@ def get_user_name():
     # Worth noting that `whoami` behaves differently to `who am i`, we need the
     # latter.
     process = subprocess.check_output(["who", "am", "i"])
-    return process.split()[0]
+    splits = process.split()
+    if splits:
+        # The format of `who am i` looks like this:
+        #
+        # clearwater      pts/1        2017-10-30 18:25 (:0)
+        #
+        # This is the login that is associated with the current user.
+        return splits[0]
+    else:
+        # `who am i` has not returned anything! This happens if the connection
+        # has been made via the console rather than over ssh. In these
+        # situations, we can use the $USER environment variable as a backup.
+        return os.getenv("USER")
 
 
 def get_user_download_dir():


### PR DESCRIPTION
Previously, if you ran cw-config via the console it didn't work. This is because `who am i` returns nothing in this circumstance. This change fixes that edge case.

I've tested this by running it with chef (which runs `cw-config` from the console). It works! Also added UT coverage for the new code.