### PR TITLE
Fixing `make verify` failure

### DIFF
--- a/src/metaswitch/clearwater/config_manager/test/test_config_access.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_access.py
@@ -230,8 +230,10 @@ class TestConfigLoader(unittest.TestCase):
 
         mock_localstore.load_config_and_revision.side_effect = IOError
 
-        config_loader = config_access.ConfigLoader(
-            etcd_client, "clearwater", "site", mock_localstore)
+        config_access.ConfigLoader(etcd_client,
+                                   "clearwater",
+                                   "site",
+                                   mock_localstore)
 
         self.assertRaises(
             config_access.ConfigUploadFailed,


### PR DESCRIPTION
There's a `make verify` failure. We shouldn't have any of those.