### PR TITLE
Python manager scripts exception logs

### DIFF
--- a/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
@@ -399,4 +399,4 @@ class CommonEtcdSynchronizer(object):
             try:
                 future.result()
             except Exception as e:
-                _log.exception(e)
+                _log.exception("%s: %s", type(e).__name__, e.__str__())

--- a/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py
@@ -30,6 +30,7 @@
 
 import etcd
 from threading import Thread
+from concurrent import futures
 from time import sleep
 from functools import wraps
 import logging
@@ -385,3 +386,17 @@ class CommonEtcdSynchronizer(object):
     def update_from_etcd(self):
         self._last_value, self._index = self.read_from_etcd(wait=True)
         return self._last_value
+    
+    # Use this class instead of the class futures.ThreadPoolExecutor to log any exceptions 
+    # that occur inside 'background-started' threads
+    class ThreadPoolExecutorWithExceptionHandler(futures.ThreadPoolExecutor):
+        def submit(self, func):
+            future = super(CommonEtcdSynchronizer.ThreadPoolExecutorWithExceptionHandler, self).submit(func)
+            future.add_done_callback(self.log_exception)
+            return future
+
+        def log_exception(self, future):
+            try:
+                future.result()
+            except Exception as e:
+                _log.exception(e)

--- a/src/metaswitch/clearwater/queue_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/queue_manager/etcd_synchronizer.py
@@ -50,7 +50,7 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
             etcd_result = None
             self._abort_read = False
 
-            executor = futures.ThreadPoolExecutor(2)
+            executor = self.ThreadPoolExecutorWithExceptionHandler(2)
             fsm_timer_future = executor.submit(self.wait_for_fsm)
             etcd_future = executor.submit(self.update_from_etcd)
             futures.wait([etcd_future, fsm_timer_future], return_when=futures.FIRST_COMPLETED)


### PR DESCRIPTION
Hi Rob, would you mind reviewing this fix for Issue 517362?

When using concurrent.futures python module for multi-threading, exceptions thrown inside of a thread do not get logged (e.g. exceptions in the _wait_for_fsm_ function in _etcd_synchronizer.py_ for clearwater queue manager). To fix this, I have modified the _ThreadPoolExecutor_ class so that when a future finishes running, the code automatically checks for any exceptions raised and logs them (this is done using the _future.add_done_callback_ method). 

I have tested the fix by adding the line "raise ValueError("Something bad has happened!")" in the 'wait_for_fsm' function in the etcd_synchronizer.py script for the clearwater-queue-manager. The following log entry was made:

13-11-2017 12:45:27.129 UTC ERROR common_etcd_synchronizer.py:402 (thread Thread-2348): ValueError: Something bad has happened!
Traceback (most recent call last):
  File "/usr/share/clearwater/clearwater-queue-manager/env/local/lib/python2.7/site-packages/metaswitch/clearwater/etcd_shared/common_etcd_synchronizer.py", line 400, in log_exception
    future.result()
  File "/usr/share/clearwater/clearwater-queue-manager/env/local/lib/python2.7/site-packages/concurrent/futures/base.py", line 398, in result
    return self._get_result()
  File "/usr/share/clearwater/clearwater-queue-manager/env/local/lib/python2.7/site-packages/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/share/clearwater/clearwater-queue-manager/env/local/lib/python2.7/site-packages/metaswitch/clearwater/queue_manager/etcd_synchronizer.py", line 92, in wait_for_fsm
    raise ValueError("Something bad has happened!")
ValueError: Something bad has happened!

I have similarly tested the _update_from_etcd_ method and run "sudo cw-upload_shared_config" to check that the queue manager still works after my change.