### PR TITLE
Prevent json config files with duplicate keys being uploaded

### DIFF
--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
@@ -101,3 +101,27 @@ if error_list:
 
     print(yaml.dump(temp_dict, default_flow_style=False).replace("u'", "'"))
     sys.exit(1)
+
+# Carry out final check, that no duplicated keys are present.
+# This check should be done last, after we have confirmed the json is valid.
+def fail_if_duplicated_keys(json_info):
+    parsed_json = dict(json_info)
+    if (len(parsed_json) != len(json_info)):
+        duplicated_key = ''
+        encountered_keys = []
+        for key in json_info:
+            if key[0] in encountered_keys:
+                duplicated_key = str(key[0])
+            else:
+                encountered_keys.append(key[0])
+        raise KeyError(duplicated_key)
+    else:
+        return parsed_json
+
+try:
+    json_file = json.load(open(config_file),
+                          object_pairs_hook=fail_if_duplicated_keys)
+except KeyError as e:
+    print "{} is not valid.".format(config_file)
+    print "It contains the key ({}) twice in the same object, which is not permitted.".format(e)
+    sys.exit(1)

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
@@ -57,7 +57,7 @@ def fail_if_duplicated_keys(json_info):
                 duplicated_key = key[0]
             else:
                 encountered_keys.append(key[0])
-        error = "Config file contains the key '{}' twice in the same item.".format(duplicated_key)
+        error = "The config file contains the key '{}' twice in the same item.".format(duplicated_key)
         raise ValueError(error)
     else:
         return parsed_json

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
@@ -45,8 +45,8 @@ except ValueError as e:
 # Check that no duplicated keys are present.
 # This check is done only after we have confirmed the json is valid.
 # This function is passed into json.load, and when json.load is called, it
-# passes each layer of the json file into this function as a list of tuples, and
-# takes the return value of this function as the parsed json.
+# passes each layer of the json file into this function as a list of tuples,
+# and takes the return value of this function as the parsed json.
 def fail_if_duplicated_keys(json_info):
     parsed_json = dict(json_info)
     if (len(parsed_json) != len(json_info)):
@@ -54,10 +54,11 @@ def fail_if_duplicated_keys(json_info):
         encountered_keys = []
         for key in json_info:
             if key[0] in encountered_keys:
-                duplicated_key = str(key[0])
+                duplicated_key = key[0]
             else:
                 encountered_keys.append(key[0])
-        raise ValueError("Config file contains the key {} twice in the same item.".format(duplicated_key))
+        error = "Config file contains the key '{}' twice in the same item.".format(duplicated_key)
+        raise ValueError(error)
     else:
         return parsed_json
 
@@ -65,7 +66,7 @@ def fail_if_duplicated_keys(json_info):
 try:
     json_file = json.load(open(config_file),
                           object_pairs_hook=fail_if_duplicated_keys)
-except KeyError as e:
+except ValueError as e:
     print "{} is not valid.".format(config_file)
     print "The errors are displayed below:"
     print e.message

--- a/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
+++ b/clearwater-config-manager.root/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py
@@ -102,6 +102,7 @@ if error_list:
     print(yaml.dump(temp_dict, default_flow_style=False).replace("u'", "'"))
     sys.exit(1)
 
+
 # Carry out final check, that no duplicated keys are present.
 # This check should be done last, after we have confirmed the json is valid.
 def fail_if_duplicated_keys(json_info):
@@ -117,6 +118,7 @@ def fail_if_duplicated_keys(json_info):
         raise KeyError(duplicated_key)
     else:
         return parsed_json
+
 
 try:
     json_file = json.load(open(config_file),


### PR DESCRIPTION
The issue - we validate a schema which has duplicate keys.
For example, the below rph.json config file would be validated and uploaded:
```
{
  "priority_blocks":[
    {
      "priority":1,
      "priority":2,
      "rph_values":["wps.0"]
    }
  ],
  "priority_blocks":[]
}
```
This isn't good. What is the priority of wps.0? 1? 2? Default?
We need to flag this error to the user, and prevent the upload.

There is not capability to prevent this in the schemas, so additional code is necessary.
The code I have added will prevent json files with duplicated keys from being validated, so their upload will be blocked.

I've tested this live, but haven't written any UTs (validate_json.py is not currently UTed, and this change wasn't big enough to merit adding a whole framework).