### PR TITLE
[Reviewer: Richard] Log detail if test fails

### DIFF
--- a/src/metaswitch/clearwater/etcd_tests/etcdcluster.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdcluster.py
@@ -5,7 +5,7 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-from shutil import rmtree, copytree
+from shutil import rmtree
 from .etcdserver import EtcdServer
 from metaswitch.common.logging_config import configure_test_logging
 configure_test_logging()
@@ -14,7 +14,6 @@ configure_test_logging()
 class EtcdCluster(object):
     def __init__(self, n=1):
         self.datadir = "./etcd_test_data"
-        self.backup_dir = "./debug_backup_test_data"
         self.servers = {}
         self.pool = ["127.0.0.{}".format(last_byte)  for last_byte in range (100, 150)]
         self.initialise_servers(n)
@@ -51,10 +50,6 @@ class EtcdCluster(object):
 
     def __del__(self):
         self.delete_datadir()
-
-    def backup_datadir(self):
-        rmtree(self.backup_dir, True)
-        copytree(self.datadir, self.backup_dir)
 
     def delete_datadir(self):
         rmtree(self.datadir, True)

--- a/src/metaswitch/clearwater/etcd_tests/etcdcluster.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdcluster.py
@@ -15,7 +15,7 @@ class EtcdCluster(object):
     def __init__(self, n=1):
         self.datadir = "./etcd_test_data"
         self.servers = {}
-        self.pool = ["127.0.0.{}".format(last_byte)  for last_byte in range (100, 150)]
+        self.pool = ["127.0.0.{}".format(last_byte) for last_byte in range(100, 150)]
         self.initialise_servers(n)
 
     def get_live_server(self):
@@ -55,12 +55,10 @@ class EtcdCluster(object):
         rmtree(self.datadir, True)
 
     def debug(self):
-        dbg = ("Cluster servers - {}\n".format(self.servers.keys()))
+        print ("Server list - {}".format(self.servers.keys()))
         for server in self.servers.values():
-            dbg += "==============================\n"
-            dbg += repr(server)
-            dbg += "server stats - {}".format(server.getStats())
-            dbg += "isLeader - {}\n".format(server.isLeader())
-            dbg += "memberList - {}\n".format(server.memberList())
-            dbg += "isAlive - {}\n".format(server.isAlive())
-        print dbg
+            print "=============================="
+            print repr(server)
+            print "server stats - {}".format(server.getStats())
+            print "memberList - {}".format(server.memberList())
+            print "isAlive - {}".format(server.isAlive())

--- a/src/metaswitch/clearwater/etcd_tests/etcdcluster.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdcluster.py
@@ -5,7 +5,7 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-from shutil import rmtree
+from shutil import rmtree, copytree
 from .etcdserver import EtcdServer
 from metaswitch.common.logging_config import configure_test_logging
 configure_test_logging()
@@ -14,6 +14,7 @@ configure_test_logging()
 class EtcdCluster(object):
     def __init__(self, n=1):
         self.datadir = "./etcd_test_data"
+        self.backup_dir = "./debug_backup_test_data"
         self.servers = {}
         self.pool = ["127.0.0.{}".format(last_byte)  for last_byte in range (100, 150)]
         self.initialise_servers(n)
@@ -51,6 +52,20 @@ class EtcdCluster(object):
     def __del__(self):
         self.delete_datadir()
 
+    def backup_datadir(self):
+        rmtree(self.backup_dir, True)
+        copytree(self.datadir, self.backup_dir)
+
     def delete_datadir(self):
         rmtree(self.datadir, True)
 
+    def debug(self):
+        dbg = ("Cluster servers - {}\n".format(self.servers.keys()))
+        for server in self.servers.values():
+            dbg += "==============================\n"
+            dbg += repr(server)
+            dbg += "server stats - {}".format(server.getStats())
+            dbg += "isLeader - {}\n".format(server.isLeader())
+            dbg += "memberList - {}\n".format(server.memberList())
+            dbg += "isAlive - {}\n".format(server.isAlive())
+        print dbg

--- a/src/metaswitch/clearwater/etcd_tests/etcdserver.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdserver.py
@@ -123,10 +123,13 @@ class EtcdServer(object):
         return ((rsp.status == 200) or (rsp.status == 201))
 
     def isLeader(self):
+        rsp = self.getStats()
+        return json.loads(rsp)['state'] == "StateLeader"
+
+    def getStats(self):
         cxn = httplib.HTTPConnection(self._ip, 4000)
         cxn.request("GET", "/v2/stats/self");
-        rsp = cxn.getresponse().read()
-        return json.loads(rsp)['state'] == "StateLeader"
+        return cxn.getresponse().read()
 
     def __del__(self):
         # Kill the etcd subprocess on destruction
@@ -156,3 +159,12 @@ class EtcdServer(object):
 
     def client(self):
         return etcd.Client(self._ip, port=4000)
+
+    def __repr__(self):
+        return ("IP - {}\n"
+                "'Existing' - {}\n"
+                "Name - {}\n"
+                "cmd - {}\n"
+                "subprocess - {}\n"
+                "datadir - {}\n"
+                .format(self._ip, self._existing, self._name, self._cmd, self._subprocess, self._datadir))

--- a/src/metaswitch/clearwater/etcd_tests/etcdserver.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdserver.py
@@ -20,6 +20,7 @@ base_cmd =              """clearwater-etcd/usr/share/clearwater/clearwater-etcd/
 first_member_cmd =      base_cmd + """ --initial-cluster-state new --initial-cluster {1}=http://{0}:2380"""
 subsequent_member_cmd = base_cmd + """ --initial-cluster-state existing --initial-cluster {3},{1}=http://{0}:2380"""
 
+
 class EtcdServer(object):
     def __init__(self, ip, datadir, existing=None, actually_start=True):
         self._ip = ip
@@ -78,7 +79,6 @@ class EtcdServer(object):
                     # https://github.com/Metaswitch/clearwater-etcd/issues/203#issuecomment-156709911
                     m['name'] = str(uuid.uuid4())
 
-
             cluster = ",".join(["{}={}".format(m['name'], m['peerURLs'][0]) for m in member_data['members'] if m['peerURLs'][0] != my_url])
             self._cmd = shlex.split(subsequent_member_cmd.format(self._ip, self._name, self._datadir, cluster))
 
@@ -96,7 +96,7 @@ class EtcdServer(object):
     def cluster_id(self):
         if self._id is None:
             # TODO: learn my ID (c.f. the code in start_process)
-            members = self.memberList() # noqa
+            members = self.memberList()  # noqa
             pass
         return self._id
 
@@ -161,10 +161,11 @@ class EtcdServer(object):
         return etcd.Client(self._ip, port=4000)
 
     def __repr__(self):
-        return ("IP - {}\n"
-                "'Existing' - {}\n"
-                "Name - {}\n"
+        return ("Name/IP - {}/{}\n"
+                "Existing nodes - {}\n"
                 "cmd - {}\n"
-                "subprocess - {}\n"
-                "datadir - {}\n"
-                .format(self._ip, self._existing, self._name, self._cmd, self._subprocess, self._datadir))
+                "datadir - {}"
+                .format(self._name, self._ip,
+                        self._existing,
+                        self._cmd,
+                        self._datadir))

--- a/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
@@ -17,7 +17,13 @@ class EtcdTestBase(unittest.TestCase):
         c = EtcdCluster(2)
         s1, s2 = c.servers.values()
 
-        hasOneLeader = s1.isLeader() != s2.isLeader()
+        s1_leader = s1.isLeader()
+        s2_leader = s2.isLeader()
+        hasOneLeader = s1_leader != s2_leader
+        if not hasOneLeader:
+            print ("\ns1: {}, isLeader {}"
+                   "\ns2: {}, isLeader {}".format(s1._ip, s1_leader,
+                                                  s2._ip, s2_leader))
 
         self.assertTrue(hasOneLeader)
         self.assertTrue(s1.memberList() == s2.memberList())

--- a/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
@@ -26,7 +26,6 @@ class EtcdTestBase(unittest.TestCase):
                    "     s2: {}, isLeader {}\n"
                    "Dumping debug information:\n".format(s1._ip, s1_leader, s2._ip, s2_leader))
             c.debug()
-            c.backup_datadir()
 
         self.assertTrue(hasOneLeader)
         self.assertTrue(s1.memberList() == s2.memberList())

--- a/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
@@ -24,7 +24,8 @@ class EtcdTestBase(unittest.TestCase):
             print ("\nExpected only one leader\n"
                    "     s1: {}, isLeader {}\n"
                    "     s2: {}, isLeader {}\n"
-                   "Dumping debug information:\n".format(s1._ip, s1_leader, s2._ip, s2_leader))
+                   "Dumping debug information:\n".format(s1._ip, s1_leader,
+                                                         s2._ip, s2_leader))
             c.debug()
 
         self.assertTrue(hasOneLeader)

--- a/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
@@ -21,9 +21,12 @@ class EtcdTestBase(unittest.TestCase):
         s2_leader = s2.isLeader()
         hasOneLeader = s1_leader != s2_leader
         if not hasOneLeader:
-            print ("\ns1: {}, isLeader {}"
-                   "\ns2: {}, isLeader {}".format(s1._ip, s1_leader,
-                                                  s2._ip, s2_leader))
+            print ("Expected only one leader\n"
+                   "     s1: {}, isLeader {}\n"
+                   "     s2: {}, isLeader {}\n"
+                   "Dumping debug information:\n".format(s1._ip, s1_leader, s2._ip, s2_leader))
+            c.debug()
+            c.backup_datadir()
 
         self.assertTrue(hasOneLeader)
         self.assertTrue(s1.memberList() == s2.memberList())

--- a/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
+++ b/src/metaswitch/clearwater/etcd_tests/etcdtestbase.py
@@ -21,7 +21,7 @@ class EtcdTestBase(unittest.TestCase):
         s2_leader = s2.isLeader()
         hasOneLeader = s1_leader != s2_leader
         if not hasOneLeader:
-            print ("Expected only one leader\n"
+            print ("\nExpected only one leader\n"
                    "     s1: {}, isLeader {}\n"
                    "     s2: {}, isLeader {}\n"
                    "Dumping debug information:\n".format(s1._ip, s1_leader, s2._ip, s2_leader))


### PR DESCRIPTION
Hopefully this should give us a slightly better idea of what's going on if we hit errors in this area again. I think it must have been some weird interaction between different jobs on the build machine, though not sure what as you said it's all run isolated.

I forced the log out by removing the 'not', and it comes out as:
```
test_basic_clustering (metaswitch.clearwater.etcd_tests.etcdtestbase.EtcdTestBase) ...
s1: 127.0.0.148, isLeader False
s2: 127.0.0.149, isLeader True
ok
test_large_clusters (metaswitch.clearwater.etcd_tests.etcdtestbase.EtcdTestBase) ... ok
```
Not really sure we can do anything more on this atm, though open to suggestions of any more information that might be useful. 