### PR TITLE
Changes to config_access to allow non-ascii comments in the config

### DIFF
--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -815,8 +815,8 @@ def print_diff_and_syslog(config_type, config_1, config_2):
     Returns True if there are changes, that need to be uploaded, or False if
     the two are the same.
     """
-    # This makes sure that both configs strings to avoid issues with combining
-    #  unicode and strings together
+    # This makes sure that both configs are strings to avoid issues with
+    # combining unicode and strings together
     if isinstance(config_1, unicode):
         config_1 = config_1.encode('utf-8')
     if isinstance(config_1, unicode):

--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -179,7 +179,8 @@ class ConfigLoader(object):
         """Save a copy of a given config type to the specified local store.
         Raises a ConfigDownloadFailed exception if unsuccessful."""
         value, index = self.get_config_and_index(selected_config)
-        value = value.encode('utf-8')
+        if isinstance(value, unicode):
+            value = value.encode('utf-8')
 
         # Write the config to file.
         try:

--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -853,9 +853,9 @@ def print_diff_and_syslog(config_type, config_1, config_2):
         log.info(output_str)
         print(output_str)
 
+        # The output_str gets encoded as 'utf-8' during audit_log() and you
+        # cannot encode utf-8 as utf-8.
         output_str = output_str.decode('utf-8')
-        # the output_str gets encoded as 'utf-8' during audit_log() and you
-        # cannot encode utf-8 as utf-8
         audit_log(output_str)
 
         return True

--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -179,6 +179,7 @@ class ConfigLoader(object):
         """Save a copy of a given config type to the specified local store.
         Raises a ConfigDownloadFailed exception if unsuccessful."""
         value, index = self.get_config_and_index(selected_config)
+        value = value.encode('utf-8')
 
         # Write the config to file.
         try:
@@ -814,6 +815,12 @@ def print_diff_and_syslog(config_type, config_1, config_2):
     Returns True if there are changes, that need to be uploaded, or False if
     the two are the same.
     """
+    # This makes sure that both configs strings to avoid issues with combining
+    #  unicode and strings together
+    if isinstance(config_1, unicode):
+        config_1 = config_1.encode('utf-8')
+    if isinstance(config_1, unicode):
+        config_2 = config_2.encode('utf-8')
 
     unified_diff = use_unified_diff(config_type)
     if unified_diff:
@@ -845,6 +852,9 @@ def print_diff_and_syslog(config_type, config_1, config_2):
         log.info(output_str)
         print(output_str)
 
+        output_str = output_str.decode('utf-8')
+        # the output_str gets encoded as 'utf-8' during audit_log() and you
+        # cannot encode utf-8 as utf-8
         audit_log(output_str)
 
         return True


### PR DESCRIPTION
This changes has been made to avoid issues with non-ascii characters. This has mainly involved changes in the upload step especially with preparing for syslog, though one change has been made to the download step as well.
I have live tested this on a node on both shared_config and dns_json.

I'm just going to tag you in this @kenferguson as it was on top of your recent changes https://github.com/Metaswitch/clearwater-etcd/pull/544 if you are interested.
