### PR TITLE
Updates validate process during cw-config

### DIFF
--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -594,7 +594,17 @@ def validate_config(selected_config, force=False):
 
     # selected_config is an instance of the ConfigType class. validate() uses
     # different scripts to validate against for different ConfigType classes.
-    failed_scripts, error_lines = selected_config.validate()
+    (failed_scripts, error_lines,
+     passed_scripts, passed_msgs) = selected_config.validate()
+
+    if passed_scripts:
+        print ("Validation passed in scripts:\n"
+               " {}\n"
+               "Output from passed scripts:\n"
+               " {}").format("\n ".join(os.path.basename(script)
+                                        for script in passed_scripts),
+                             "\n ".join(passed_msgs))
+
 
     # In the forcing case, we proceed even if there have been failures, but
     # otherwise we want to bail out at this point.

--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -597,7 +597,7 @@ def validate_config(selected_config, force=False):
     (failed_scripts, error_lines,
      passed_scripts, passed_msgs) = selected_config.validate()
 
-    if passed_scripts:
+    if passed_scripts and passed_msgs:
         print ("Validation passed in scripts:\n"
                " {}\n"
                "Output from passed scripts:\n"

--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -797,7 +797,8 @@ def get_per_line_diffs(old_config, new_config):
 
     return diff_info
 
-def get_unified_diff (old_config, new_config):
+
+def get_unified_diff(old_config, new_config):
     """Generate a unified diff of the changes between the old and new
     configuration. Returns a new-line-separated string of the changes.
     """
@@ -807,7 +808,8 @@ def get_unified_diff (old_config, new_config):
                                 n=3)
     return "\n".join(diff)
 
-def use_unified_diff (config_type):
+
+def use_unified_diff(config_type):
     """Determine whether to use a unified diff for a piece of config"""
 
     config_info = lookup_config_type(config_type)
@@ -820,6 +822,7 @@ def use_unified_diff (config_type):
 
     return unified_diff
 
+
 def print_diff_and_syslog(config_type, config_1, config_2):
     """
     Print a readable diff of changes between two texts and log to syslog.
@@ -830,7 +833,7 @@ def print_diff_and_syslog(config_type, config_1, config_2):
     # combining unicode and strings together
     if isinstance(config_1, unicode):
         config_1 = config_1.encode('utf-8')
-    if isinstance(config_1, unicode):
+    if isinstance(config_2, unicode):
         config_2 = config_2.encode('utf-8')
 
     unified_diff = use_unified_diff(config_type)
@@ -838,7 +841,7 @@ def print_diff_and_syslog(config_type, config_1, config_2):
         log.debug("Generating unified diff")
         unified_diff = get_unified_diff(config_1, config_2)
         if len(unified_diff) > 0:
-            diff_info = { "Changes:" : [ unified_diff ] }
+            diff_info = {"Changes:": [unified_diff]}
         else:
             diff_info = None
     else:
@@ -895,6 +898,7 @@ def read_from_file(file_path):
         raise
 
     return contents
+
 
 def reset_file_ownership(filepath):
     """If a user runs this module with `sudo`, any created files or directories

--- a/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
+++ b/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
@@ -117,10 +117,17 @@ class ConfigType:
 
         failed_scripts = []
         error_lines = []
+        passed_scripts = []
+        success_lines = []
         for script in self.scripts:
             try:
                 log.debug("Running validation script %s", script)
-                subprocess.check_output(self.scripts[script], stderr=subprocess.STDOUT)
+                out_print = subprocess.check_output(self.scripts[script],
+                                                    stderr=subprocess.STDOUT)
+                if out_print:
+                    out_msg = out_print.splitlines()
+                    success_lines.extend(out_msg)
+                passed_scripts.append(script)
             except subprocess.CalledProcessError as exc:
                 log.error("Validation script %s failed", os.path.basename(script))
                 log.error("Reasons for failure:")
@@ -137,4 +144,5 @@ class ConfigType:
                 # which scripts have failed. If any scripts have failed an
                 # exception is raised from the return value
                 failed_scripts.append(script)
-        return failed_scripts, error_lines
+        return failed_scripts, error_lines, passed_scripts, success_lines
+

--- a/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
+++ b/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
@@ -122,11 +122,10 @@ class ConfigType:
         for script in self.scripts:
             try:
                 log.debug("Running validation script %s", script)
-                out_print = subprocess.check_output(self.scripts[script],
-                                                    stderr=subprocess.STDOUT)
-                if out_print:
-                    out_msg = out_print.splitlines()
-                    success_lines.extend(out_msg)
+                output = subprocess.check_output(self.scripts[script],
+                                                 stderr=subprocess.STDOUT)
+                out_msg = output.splitlines()
+                success_lines.extend(out_msg)
                 passed_scripts.append(script)
             except subprocess.CalledProcessError as exc:
                 log.error("Validation script %s failed", os.path.basename(script))

--- a/src/metaswitch/clearwater/config_manager/test/test_config_access.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_access.py
@@ -892,22 +892,25 @@ class TestValidation(unittest.TestCase):
 
     def test_handle_validation_error(self, mock_selected_config):
         """Test that we handle validation failure correctly."""
-        mock_selected_config.validate.return_value = (['script1'], ['ERROR: '])
-        # a script has failed and is in failed_scripts.
+        mock_selected_config.validate.return_value = (['script1'], ['ERROR: '],
+                                                      [], [])
+        # A script has failed and is in failed_scripts.
         with self.assertRaises(config_access.ConfigValidationFailed):
             config_access.validate_config(mock_selected_config, False)
 
     def test_ignore_validation_error(self, mock_selected_config):
         """Test that we ignore validation failure correctly in the force
         case."""
-        mock_selected_config.validate.return_value = (['script1'], ['ERROR: '])
+        mock_selected_config.validate.return_value = (['script1'], ['ERROR: '],
+                                                      [], [])
         # Even though subprocess raises an exception, we continue because
         # we're in force mode.
         config_access.validate_config(mock_selected_config, True)
 
     def test_no_errors(self, mock_selected_config):
         """test everything runs ok when it returns no errors"""
-        mock_selected_config.validate.return_value = ([], [])
+        mock_selected_config.validate.return_value = ([], [], ['script1'],
+                                                      ['WARN: Something'])
         config_access.validate_config(mock_selected_config, False)
 
 

--- a/src/metaswitch/clearwater/config_manager/test/test_config_type.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_type.py
@@ -53,7 +53,7 @@ class TestConfigTypeClassPlugin(unittest.TestCase):
         shared_config.scripts = {'name1': ['script1'], 'name2': ['script2']}
         validation_error = subprocess.CalledProcessError('A', 'B')
         validation_error.output = "ERROR: Something went wrong"
-        mock_subprocess.side_effect = [None, validation_error]
+        mock_subprocess.side_effect = ["", validation_error]
         # possibly want to run this within assertRaises check as well
         answer = shared_config.validate()
 


### PR DESCRIPTION
This adds a way to print out any messages from successful validation and say which scripts have passed
Also changes the unit tests based on these changes.

I haven't done live testing of this for the configs other than shared_config which may cause it to change in the future if they over print to screen.
