### PR TITLE
[Reviewer: MD6] Fix process name matching - 'etcd' not 'clearwater-etcd'

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -384,7 +384,7 @@ do_start()
         #   0 if daemon has been started
         #   1 if daemon was already running
         #   2 if daemon could not be started
-        start-stop-daemon --start --quiet --pidfile $PIDFILE --name $NAME --startas $DAEMONWRAPPER --test > /dev/null \
+        start-stop-daemon --start --quiet --pidfile $PIDFILE --name $(basename $DAEMON) --startas $DAEMONWRAPPER --test > /dev/null \
                 || return 1
 
         ETCD_NAME=${advertisement_ip//./-}
@@ -551,7 +551,7 @@ do_reload() {
         # restarting (for example, when it is sent a SIGHUP),
         # then implement that here.
         #
-        start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+        start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $(basename $DAEMON)
         return 0
 }
 


### PR DESCRIPTION
We saw an issue where two instances of etcd had been started on a node, causing chaos. This `start-stop-daemon ... --test` line is meant to prevent that, but it was using `--name clearwater-etcd` when the process's name is just `etcd`, so wasn't matching on the right process.

Looks like this has been in the code forever. (You're raising an issue so there's a record of it).

This change should fix it - I've tested that basename does the right thing:

```
13:56:11-rkd@abra:~/salinas$ echo $(basename /usr/share/clearwater/clearwater-etcd/3.1.7/etcd)
etcd
```

and I'll copy this init.d file onto a system and reboot to test it live before merging.

@eleanor-merry , any comments given your etcd experience?