### PR TITLE
[Reviewer: Adam] Ensure queue_operation.log is writable on upgrade

### DIFF
--- a/debian/clearwater-queue-manager.postinst
+++ b/debian/clearwater-queue-manager.postinst
@@ -47,6 +47,10 @@ case "$1" in
         chown -R $NAME:adm /var/log/$NAME
         chmod g+s /var/log/$NAME
 
+        # Need to fix up the permission on the queue operation file if it
+        # already exists
+        chmod g+w /var/log/clearwater-queue-manager/queue_operation.log
+
         # Set up the virtual env
         rm -rf $BASE_DIR/env
         virtualenv --python=$(which python) $BASE_DIR/env


### PR DESCRIPTION
With the new `cw-config` manager, the `queue_operation.log` file needs to be writable to `adm` users. On upgrade, the log file isn't writable.

I've tested by making the file non-writable, upgrading to this fix, and checking that the file is now writable.