### PR TITLE
[Reviewer: Seb] Fix up etcd tests and requirements

### DIFF
--- a/config_mgr_setup.py
+++ b/config_mgr_setup.py
@@ -26,7 +26,8 @@ setup(
     install_requires=[
         "clearwater_etcd_shared",
         "metaswitchcommon",
-        "requests"],
+        "requests",
+        "jsonschema"],
     tests_require=[
         "funcsigs",
         "Mock",

--- a/src/metaswitch/clearwater/config_manager/test/test_config_type.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_type.py
@@ -107,7 +107,7 @@ class TestGetValidationScripts(unittest.TestCase):
         # currently only one
         scscf_json = scscf_json_config_plugin.ScscfJson('path')
         answer = scscf_json.get_json_validation()
-        scscsf_expected_script = [['python',
+        scscsf_expected_script = [['/usr/share/clearwater/clearwater-config-manager/env/bin/python',
                                    '/usr/share/clearwater/clearwater-config-manager/scripts/validate_json.py',
                                    '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/scscf_schema.json',
                                    'path']]


### PR DESCRIPTION
Seb,

This follows on from https://github.com/Metaswitch/clearwater-etcd/pull/554

This adds the required requirement in `setup.py` for jsonschema (required by `validate_json.py`), and fixes up the test to need the expected virtual environment.