### PR TITLE
bandit medium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /build/
 /htmlcov/
 /src/*.egg-info/
+*_eggs/
 coverage.xml
 
 # Alarm constants generated from JSON files

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
@@ -32,7 +32,7 @@ try:
     # it is syntactically marked for shell injection risk, while using a literal
     # string as command does not actually pose a risk of it.
     desc_cluster_output = subprocess.check_output(command, shell=True)  # nosec
-    doc = yaml.load(desc_cluster_output)
+    doc = yaml.safe_load(desc_cluster_output)
     servers = doc["Cluster Information"]["Schema versions"].values()[0]
     data = json.dumps({server: "normal" for server in servers})
 

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -34,11 +34,10 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 break
 
             if value and value != old_value:
-                _log.info("Got new config value from etcd - filename {}, file
-                        size {}, SHA512 hash {}".format(
-                            self._plugin.file(),
-                            len(value),
-                            sha512(utils.safely_encode(value)).hexdigest()))
+                _log.info("Got new config value from etcd - filename {}, file size {}, SHA512 hash {}".format(
+                    self._plugin.file(),
+                    len(value),
+                    sha512(utils.safely_encode(value)).hexdigest()))
                 _log.debug("Got new config value from etcd:\n{}".format(
                            utils.safely_encode(value)))
                 self._plugin.on_config_changed(value, self._alarm)

--- a/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
+++ b/src/metaswitch/clearwater/config_manager/etcd_synchronizer.py
@@ -5,7 +5,7 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-from hashlib import md5
+from hashlib import sha512
 
 from .pdlogs import FILE_CHANGED
 from metaswitch.clearwater.etcd_shared.common_etcd_synchronizer import CommonEtcdSynchronizer
@@ -34,10 +34,11 @@ class EtcdSynchronizer(CommonEtcdSynchronizer):
                 break
 
             if value and value != old_value:
-                _log.info("Got new config value from etcd - filename {}, file size {}, MD5 hash {}".format(
-                    self._plugin.file(),
-                    len(value),
-                    md5(utils.safely_encode(value)).hexdigest()))
+                _log.info("Got new config value from etcd - filename {}, file
+                        size {}, SHA512 hash {}".format(
+                            self._plugin.file(),
+                            len(value),
+                            sha512(utils.safely_encode(value)).hexdigest()))
                 _log.debug("Got new config value from etcd:\n{}".format(
                            utils.safely_encode(value)))
                 self._plugin.on_config_changed(value, self._alarm)


### PR DESCRIPTION
yaml safe load; sha512 instead of md5
uses sha512 version of python common

`make test` passed, already has the plugin yaml safe load