### PR TITLE
[Reviewer: Ellie] Add process ID to clearwater-etcd-initd.log

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -41,11 +41,12 @@ etcd_version=3.1.7
 
 DAEMON=/usr/share/clearwater/clearwater-etcd/$etcd_version/etcd
 DAEMONWRAPPER=/usr/share/clearwater/clearwater-etcd/$etcd_version/etcdwrapper
+MYPID=$$
 
 # Log parameters at "debug" level. These are just written to the log file (with
 # timestamps).
 log_debug() {
-  echo $(date +'%Y-%m-%d %H:%M:%S.%N') "$@" >> $LOG_FILE
+  echo $(date +'%Y-%m-%d %H:%M:%S.%N') "[$MYPID]" "$@" >> $LOG_FILE
 }
 
 # Log parameters at "info" level. These are written to the console (without


### PR DESCRIPTION
These are the logs I suggested in https://github.com/Metaswitch/clearwater-issues/issues/2883.

Tested live:

```
[scn]clearwater@grdeployment-site2-scn-2:~$ tail /var/log/clearwater-etcd/clearwater-etcd-initd.log
2018-01-15 18:06:42.367873180 [30851] Restarting etcd clearwater-etcd
2018-01-15 18:06:42.373201306 [30851] Configured ETCDCTL_PEERS: 10.1.4.130:4000,
2018-01-15 18:06:42.373820222 [30851] Check for previous failed startup attempt
2018-01-15 18:06:42.374754371 [30851] Running etcdctl member list
Failed to get leader:  client: etcd cluster is unavailable or misconfigured; error #0: client: etcd member http://10.1.4.132:4000 has no leader
; error #1: client: etcd member http://10.1.4.130:4000 has no leader
; error #2: dial tcp 10.1.4.131:4000: getsockopt: connection refused

2018-01-15 18:06:42.387177807 [30851] etcdctl returned 1
2018-01-15 18:06:42.392283370 [30851] Joining existing cluster...
```