### PR TITLE
[Post-reviewer: EM] Log who called us - monit or upstart?

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -556,6 +556,9 @@ do_reload() {
         return 0
 }
 
+log_debug "Invoked with argument '$1'"
+log_debug "Process tree: " $(pstree -p -s $MYPID)
+
 # There should only be at most one etcd process, and it should be the one in /var/run/clearwater-etcd/clearwater-etcd.pid.
 # Sanity check this, and kill and log any leaked ones.
 if [ -f $PIDFILE ] ; then


### PR DESCRIPTION
Similar to https://github.com/Metaswitch/clearwater-etcd/pull/562, this improves the logging in the init script. Specifically, this logs out our process ancestors, e.g.

```
2018-01-15 18:55:22.469394237 [6364] Invoked with argument 'restart'
2018-01-15 18:55:22.473594571 [6364] Process tree:  init(1)---monit(1671)---bash(6360)---clearwater-etcd(6364)---pstree(6377)
```

I'm hoping this will prove my hypothesis that etcd sometimes gets started by monit and sometimes directly by upstart.

I'm merging without review to get in tonight's build.