### PR TITLE
[Reviewer: Ellie] Log which files are causing config sync alarms

### DIFF
--- a/src/metaswitch/clearwater/config_manager/alarms.py
+++ b/src/metaswitch/clearwater/config_manager/alarms.py
@@ -45,6 +45,10 @@ class ConfigAlarm(object):
         if all(self._files.values()):
             self._alarm.clear()
         else:
-            _log.warning("Config not in sync - status: " + str(self._files))
+            out_of_sync = [filename for filename in self._files if not
+                    self._files[filename]]
+
+            _log.warning("Config is not in sync - the following files are "
+                "out of sync: {}".format(out_of_sync))
             self._alarm.set()
             pdlogs.NO_SHARED_CONFIG_ALARM.log()

--- a/src/metaswitch/clearwater/config_manager/alarms.py
+++ b/src/metaswitch/clearwater/config_manager/alarms.py
@@ -45,5 +45,6 @@ class ConfigAlarm(object):
         if all(self._files.values()):
             self._alarm.clear()
         else:
+            _log.warning("Config not in sync - status: " + str(self._files))
             self._alarm.set()
             pdlogs.NO_SHARED_CONFIG_ALARM.log()


### PR DESCRIPTION
Ellie,

Post trying to debug a config alarm on Friday, I've added a log line to config manager to log when we raise an alarm.

I'm fairly confident we won't just spam this, and will instead just notify when the reason for raising the alarm changes, or config manager restarts, so I think this is safe. I've tested the change in Chef.

Sample alarm text is:

```
29-01-2018 12:20:13.600 UTC WARNING alarms.py:48 (thread SharedIFCsXMLPlugin): Config not in sync - status: {'/etc/clearwater/bgcf.json': True, '/etc/clearwater/shared_ifcs.xml': True, '/etc/clearwater/shared_config': False, '/etc/clearwater/fallback_ifcs.xml': True, '/etc/clearwater/rph.json': True, '/etc/clearwater/s-cscf.json': True, '/etc/clearwater/dns.json': True, '/etc/clearwater/enum.json': True}
```

where `True` indicates a file is in sync, and False indicates otherwise.

(As a bonus, this means the logger in alarms.py is now actually used!)

`make full_test` passes.