### PR TITLE
[Reviewer: Sathiyan] Stop the load from cassandra scripts needing sudo

### DIFF
--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster
@@ -11,8 +11,6 @@
 
 set -ue
 
-. /usr/share/clearwater/utils/check-root-permissions 1
-
 etcd_key=clearwater
 . /etc/clearwater/config
 

--- a/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
+++ b/clearwater-cluster-manager.root/usr/share/clearwater/clearwater-cluster-manager/scripts/load_from_cassandra_cluster.py
@@ -25,10 +25,10 @@ try:
     # Use nodetool describecluster to find the nodes in the existing cluster.
     # This returns a yaml document, but in order for pyyaml to recognise the
     # output as valid yaml, we need to use tr to replace tabs with spaces.
-    # We remove any xss=.., as this can be printed out by 
+    # We remove any xss=.., as this can be printed out by
     # cassandra-env.sh
-    command = "/usr/share/clearwater/bin/run-in-signaling-namespace nodetool describecluster | grep -v \"^xss = \" | tr \"\t\" \" \""
-    # The following line has a comment to leave it out for Bandit analysis, as 
+    command = "cw-run_in_signaling_namespace nodetool describecluster | grep -v \"^xss = \" | tr \"\t\" \" \""
+    # The following line has a comment to leave it out for Bandit analysis, as
     # it is syntactically marked for shell injection risk, while using a literal
     # string as command does not actually pose a risk of it.
     desc_cluster_output = subprocess.check_output(command, shell=True)  # nosec


### PR DESCRIPTION
The load_from_cassandra_cluster scripts require sudo. They shouldn't - an admin user should be allowed to run these scripts.