### PR TITLE
[Reviewer: KAF] Progressive output config upload

### DIFF
--- a/src/metaswitch/clearwater/config_manager/config_access.py
+++ b/src/metaswitch/clearwater/config_manager/config_access.py
@@ -594,16 +594,12 @@ def validate_config(selected_config, force=False):
 
     # selected_config is an instance of the ConfigType class. validate() uses
     # different scripts to validate against for different ConfigType classes.
-    (failed_scripts, error_lines,
-     passed_scripts, passed_msgs) = selected_config.validate()
+    (failed_scripts, passed_scripts) = selected_config.validate()
 
-    if passed_scripts and passed_msgs:
+    if passed_scripts:
         print ("Validation passed in scripts:\n"
-               " {}\n"
-               "Output from passed scripts:\n"
-               " {}").format("\n ".join(os.path.basename(script)
-                                        for script in passed_scripts),
-                             "\n ".join(passed_msgs))
+               " {}\n".format("\n ".join(os.path.basename(script)
+                                         for script in passed_scripts)))
 
 
     # In the forcing case, we proceed even if there have been failures, but
@@ -612,11 +608,8 @@ def validate_config(selected_config, force=False):
         log.error("One or more validation scripts have failed, aborting")
         raise ConfigValidationFailed(
             "Validation failed while executing scripts:\n"
-            " {}\n"
-            "Errors:\n"
-            " {}".format("\n ".join(os.path.basename(script)
-                                    for script in failed_scripts),
-                         "\n ".join(error_lines)))
+            " {}\n".format("\n ".join(os.path.basename(script)
+                                      for script in failed_scripts)))
 
     if failed_scripts:
         # We can only get here in the forcing case.

--- a/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
+++ b/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
@@ -125,13 +125,15 @@ class ConfigType:
             try:
                 msg = "Running validation script {}".format(os.path.basename(script))
                 log.debug(msg)
-                print("{}\n".format(msg))
+                print(msg)
                 subprocess.check_call(self.scripts[script],
                                       stderr=subprocess.STDOUT)
                 passed_scripts.append(script)
 
             except subprocess.CalledProcessError as exc:
-                log.error("Validation script {} failed".format(os.path.basename(script)))
+                rc = exc.returncode
+                log.error("Validation script {} failed with code {}".format(
+                    os.path.basename(script), rc))
 
                 # We want to run through all the validation scripts so we can
                 # tell the user all of the problems with their config changes,

--- a/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
+++ b/src/metaswitch/clearwater/config_manager/config_type_class_plugin.py
@@ -73,8 +73,8 @@ class ConfigType:
     def get_json_validation(self):
         """Returns the scripts to be used for json file validation."""
         scripts = {}
-        scripts[self.schema] = ['/usr/share/clearwater/clearwater-config-manager/env/bin/python', 
-                                JSON_GENERIC_VALIDATE, 
+        scripts[self.schema] = ['/usr/share/clearwater/clearwater-config-manager/env/bin/python',
+                                JSON_GENERIC_VALIDATE,
                                 self.schema,
                                 self.configfile]
         # to add more validation scripts add to the dict of scripts
@@ -118,26 +118,20 @@ class ConfigType:
         """
 
         failed_scripts = []
-        error_lines = []
         passed_scripts = []
-        success_lines = []
+
+        print("")
         for script in self.scripts:
             try:
-                log.debug("Running validation script %s", script)
-                output = subprocess.check_output(self.scripts[script],
-                                                 stderr=subprocess.STDOUT)
-                out_msg = output.splitlines()
-                success_lines.extend(out_msg)
+                msg = "Running validation script {}".format(os.path.basename(script))
+                log.debug(msg)
+                print("{}\n".format(msg))
+                subprocess.check_call(self.scripts[script],
+                                      stderr=subprocess.STDOUT)
                 passed_scripts.append(script)
+
             except subprocess.CalledProcessError as exc:
-                log.error("Validation script %s failed", os.path.basename(script))
-                log.error("Reasons for failure:")
-
-                errors = exc.output.splitlines()
-                error_lines.extend(errors)
-
-                for line in errors:
-                    log.error(line)
+                log.error("Validation script {} failed".format(os.path.basename(script)))
 
                 # We want to run through all the validation scripts so we can
                 # tell the user all of the problems with their config changes,
@@ -145,5 +139,7 @@ class ConfigType:
                 # which scripts have failed. If any scripts have failed an
                 # exception is raised from the return value
                 failed_scripts.append(script)
-        return failed_scripts, error_lines, passed_scripts, success_lines
+            print("")
+
+        return failed_scripts, passed_scripts
 

--- a/src/metaswitch/clearwater/config_manager/test/test_config_access.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_access.py
@@ -911,8 +911,8 @@ class TestValidation(unittest.TestCase):
 
     def test_handle_validation_error(self, mock_selected_config):
         """Test that we handle validation failure correctly."""
-        mock_selected_config.validate.return_value = (['script1'], ['ERROR: '],
-                                                      [], [])
+        mock_selected_config.validate.return_value = (['script1'], [])
+
         # A script has failed and is in failed_scripts.
         with self.assertRaises(config_access.ConfigValidationFailed):
             config_access.validate_config(mock_selected_config, False)
@@ -920,16 +920,14 @@ class TestValidation(unittest.TestCase):
     def test_ignore_validation_error(self, mock_selected_config):
         """Test that we ignore validation failure correctly in the force
         case."""
-        mock_selected_config.validate.return_value = (['script1'], ['ERROR: '],
-                                                      [], [])
+        mock_selected_config.validate.return_value = (['script1'], [])
         # Even though subprocess raises an exception, we continue because
         # we're in force mode.
         config_access.validate_config(mock_selected_config, True)
 
     def test_no_errors(self, mock_selected_config):
         """test everything runs ok when it returns no errors"""
-        mock_selected_config.validate.return_value = ([], [], ['script1'],
-                                                      ['WARN: Something'])
+        mock_selected_config.validate.return_value = ([], ['script1'])
         config_access.validate_config(mock_selected_config, False)
 
 

--- a/src/metaswitch/clearwater/config_manager/test/test_config_type.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_type.py
@@ -46,6 +46,11 @@ class TestConfigTypeClassPlugin(unittest.TestCase):
         self.assertListEqual(answer[1], ["/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/dns_schema.json"])
         self.assertIs(mock_subprocess.call_count, 1)
 
+    def test_bgcf_plugin_creatable(self, mock_subprocess, mock_log):
+        """Just loads the BGCF plugin and checks it can be created."""
+        bgcf_config = bgcf_json_config_plugin.BgcfJson('path')
+        self.assertIsNotNone(bgcf_config)
+
     def test_validate_fails(self, mock_subprocess, mock_log):
         """use ConfigType.validate and get subprocess to raise a exception and
          check log reports this and failed scripts is not empty"""


### PR DESCRIPTION
Currently, the `cw-config upload xxx` command collects the output of any validation scripts, and then prints it to the screen once all the validation scripts have run.

As per issue: https://github.com/Metaswitch/clearwater-issues/issues/3691, this can make it look like the config upload has hung, whereas it's actually just being slow.

This changes that so that we just allow all output to go to the screen as it's produced by the validation script. To do this, I've had to abandon collecting the output, but I don't think we lose very much by doing that, it just changes the formatting.

I've also had to fix up the UTs, one of which I've deleted as it wasn't doing anything new. I've also removed some expectations on number of logs written in the UTs, as I think that's a bad thing to do.

As an aside, I'm not a fan of the code or UT structure here at all, but I don't think now is the time to be rewriting it all, so I've tweaked what's there rather than redoing it all.

I've tested this works by manually downloading and uploading shared_config and dns_json.

I've put here some examples fo the output before and after.

#### Various outputs before:

No errors:
```
[dgn]clearwater@sr2-site1-dgn-1:~$ cw-config upload shared_config
Validation passed in scripts:
 clearwater-core-validate-config
Output from passed scripts:
 All config checks passed
Config successfully validated
No changes detected in shared_config file.
There are no differences between the local and remote configuration. No upload will be performed.
```
Errors in shared_config:
```
[dgn]clearwater@sr2-site1-dgn-1:~$ cw-config upload shared_config
Validation failed while executing scripts:
 clearwater-core-validate-config
Errors:
 ERROR: sprout_hostname: Unable to resolve domain name sprout.wrong.sr2.cwc.cw-ngv.com
 ERROR: sprout_hostname_mgmt: Unable to resolve domain name sprout-mgmt.wrong.sr2.cwc.cw-ngv.com
 ERROR: sprout_hostname: _sip._tcp.scscf.sprout.wrong.sr2.cwc.cw-ngv.com is not a valid SRV record
 ERROR: sprout_hostname: _sip._tcp.bgcf.sprout.wrong.sr2.cwc.cw-ngv.com is not a valid SRV record
 ERROR: sprout_hostname: _sip._tcp.icscf.sprout.wrong.sr2.cwc.cw-ngv.com is not a valid SRV record
```

#### Various outputs after:

no errors:
```
[dgn]clearwater@sr2-site1-dgn-1:~$ cw-config upload shared_config

Running validation script clearwater-core-validate-config

All config checks passed

Validation passed in scripts:
 clearwater-core-validate-config

Config successfully validated
No changes detected in shared_config file.
There are no differences between the local and remote configuration. No upload will be performed.
```

Errors on shared_config:
```
[dgn]clearwater@sr2-site1-dgn-1:~$ cw-config upload shared_config

Running validation script clearwater-core-validate-config

ERROR: sprout_hostname: Unable to resolve domain name sprout.sitwronge1.sr2.cwc.cw-ngv.com
ERROR: sprout_hostname_mgmt: Unable to resolve domain name sprout-mgmwrongt.site1.sr2.cwc.cw-ngv.com
ERROR: hs_hostname_mgmt: Unable to resolve domain name homestead-mgmt.sitewrong1.sr2.cwc.cw-ngv.com
ERROR: sprout_hostname: _sip._tcp.scscf.sprout.sitwronge1.sr2.cwc.cw-ngv.com is not a valid SRV record
ERROR: sprout_hostname: _sip._tcp.bgcf.sprout.sitwronge1.sr2.cwc.cw-ngv.com is not a valid SRV record
ERROR: sprout_hostname: _sip._tcp.icscf.sprout.sitwronge1.sr2.cwc.cw-ngv.com is not a valid SRV record

Validation failed while executing scripts:
 clearwater-core-validate-config

```

Errors in dns_json:
```
[dgn]clearwater@sr2-site1-dgn-1:~$ cw-config upload dns_json

Running validation script dns_schema.json

/home/clearwater/clearwater-config-manager/clearwater/dns.json is not valid.
The errors, and the location of the errors in the configuration file, are displayed below:

Expecting property name: line 11 column 5 (char 314)

Validation failed while executing scripts:
 dns_schema.json

```