### PR TITLE
[Reviewer: KAF] Fix up RPH config access plugin to use new interface

### DIFF
--- a/src/metaswitch/clearwater/config_manager/test/test_config_type.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_type.py
@@ -176,13 +176,14 @@ class TestRphValidation(unittest.TestCase):
 
     def test_validate_fails(self, mock_subprocess, mock_access, mock_log):
         """Use RphJson.validate and get subprocess to raise a exception and
-         check log reports this and failed scripts is not empty."""
+         check failed scripts is not empty."""
         rph_config = rph_json_config_plugin.RphJson(self.config_location)
         validation_error = subprocess.CalledProcessError('A', 'B')
-        validation_error.output = "ERROR: Something went wrong"
         mock_subprocess.side_effect = [validation_error]
         answer = rph_config.validate()
 
+        # The list of failed scripts should contain 'rph_validation.py', and the
+        # list of passed scripts should be empty
         self.assertListEqual(answer[0], ['rph_validation.py'])
         self.assertListEqual(answer[1], [])
         self.assertIs(mock_subprocess.call_count, 1)

--- a/src/metaswitch/clearwater/config_manager/test/test_config_type.py
+++ b/src/metaswitch/clearwater/config_manager/test/test_config_type.py
@@ -154,7 +154,7 @@ class TestDiffType(unittest.TestCase):
 # be removed.
 @mock.patch('clearwater_etcd_plugins.clearwater_config_access.rph_json_config_plugin.log')
 @mock.patch('metaswitch.clearwater.config_manager.config_type_class_plugin.os.access')
-@mock.patch('metaswitch.clearwater.config_manager.config_type_class_plugin.subprocess.check_output')
+@mock.patch('metaswitch.clearwater.config_manager.config_type_class_plugin.subprocess.check_call')
 class TestRphValidation(unittest.TestCase):
     config_location = "/some/dir/rph.json"
 
@@ -183,12 +183,8 @@ class TestRphValidation(unittest.TestCase):
         mock_subprocess.side_effect = [validation_error]
         answer = rph_config.validate()
 
-        self.assertIs(mock_log.error.call_count, 3)
-        self.assertIs(mock_log.debug.call_count, 1)
         self.assertListEqual(answer[0], ['rph_validation.py'])
-        self.assertListEqual(answer[1], ["ERROR: Something went wrong"])
-        self.assertListEqual(answer[2], [])
-        self.assertListEqual(answer[3], [])
+        self.assertListEqual(answer[1], [])
         self.assertIs(mock_subprocess.call_count, 1)
 
 


### PR DESCRIPTION
Test changes corresponding to: https://github.com/Metaswitch/clearwater-etcd-plugins/pull/60

`make full_test` passes, and I've live tested uploading valid rph_json and it works (and invalid rph_json is correctly rejected).