### PR TITLE
Don't decommission proxy nodes

### DIFF
--- a/debian/clearwater-etcd.init.d
+++ b/debian/clearwater-etcd.init.d
@@ -682,7 +682,11 @@ case "$1" in
         fi
 
         log_daemon_msg "Decommissioning etcd"
-        do_decommission
+        if [ -n "$etcd_proxy" ]; then
+          do_stop
+        else
+          do_decommission
+        fi
         exit $?
         ;;
   abort-restart)


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/clearwater-issues/issues/3772 and https://github.com/Metaswitch/dudamel/issues/2369 by simply stopping proxy etcd instances during decommissioning rather than trying to go through the full member remove processing.